### PR TITLE
update ephemeral storage and remove bitnami

### DIFF
--- a/apps/nextcloud/cronjob.yaml
+++ b/apps/nextcloud/cronjob.yaml
@@ -8,28 +8,41 @@ metadata:
     kube-score/ignore: pod-networkpolicy
 spec:
   schedule: 30 6 * * *  # UTC time. 2h30 am EST
-  startingDeadlineSeconds: 10
+  startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           serviceAccountName: backup-runner
+          restartPolicy: Never
           securityContext:
-            runAsUser: 10000
-            runAsGroup: 10000
-            fsGroup: 10000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
             - name: maint-on
-              image: bitnami/kubectl:1.33.3
-              imagePullPolicy: Always
+              image: registry.k8s.io/kubectl:v1.33.3
+              imagePullPolicy: IfNotPresent
               command:
-                - /bin/sh
-                - -c
-                - |
-                  POD=$(kubectl get pod -n nextcloud -l app.kubernetes.io/name=nextcloud -o jsonpath="{.items[0].metadata.name}")
-                  kubectl exec -n nextcloud $POD -- php occ maintenance:mode --on
+                - kubectl
+                - exec
+                - -n
+                - nextcloud
+                - deploy/nextcloud
+                - --
+                - php
+                - occ
+                - maintenance:mode
+                - --on
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 10000
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
               resources:
                 requests:
                   cpu: 10m
@@ -38,14 +51,6 @@ spec:
                   cpu: 50m
                   memory: 64Mi
                   ephemeral-storage: 50Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                capabilities:
-                  drop:
-                    - ALL
-          restartPolicy: OnFailure
 ---
 apiVersion: batch/v1
 kind: CronJob
@@ -56,28 +61,41 @@ metadata:
     kube-score/ignore: pod-networkpolicy
 spec:
   schedule: 20 7 * * *  # UTC time. 3h20 am EST
-  startingDeadlineSeconds: 10
+  startingDeadlineSeconds: 300
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      backoffLimit: 1
       template:
         spec:
           serviceAccountName: backup-runner
+          restartPolicy: OnFailure
           securityContext:
-            runAsUser: 10000
-            runAsGroup: 10000
-            fsGroup: 10000
+            seccompProfile:
+              type: RuntimeDefault
           containers:
-            - name: maint-off
-              image: bitnami/kubectl:1.33.3
-              imagePullPolicy: Always
+            - name: maint-on
+              image: registry.k8s.io/kubectl:v1.33.3
+              imagePullPolicy: IfNotPresent
               command:
-                - /bin/sh
-                - -c
-                - |
-                  POD=$(kubectl get pod -n nextcloud -l app.kubernetes.io/name=nextcloud -o jsonpath="{.items[0].metadata.name}")
-                  kubectl exec -n nextcloud $POD -- php occ maintenance:mode --off
+                - kubectl
+                - exec
+                - -n
+                - nextcloud
+                - deploy/nextcloud
+                - --
+                - php
+                - occ
+                - maintenance:mode
+                - --off
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 10000
+                readOnlyRootFilesystem: true
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
               resources:
                 requests:
                   cpu: 10m
@@ -86,14 +104,6 @@ spec:
                   cpu: 50m
                   memory: 64Mi
                   ephemeral-storage: 50Mi
-              securityContext:
-                allowPrivilegeEscalation: false
-                readOnlyRootFilesystem: true
-                runAsNonRoot: true
-                capabilities:
-                  drop:
-                    - ALL
-          restartPolicy: OnFailure
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -110,6 +120,9 @@ rules:
   - apiGroups: ['']
     resources: [pods, pods/exec]
     verbs: [get, list, create, delete]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/apps/nextcloud/cronjob.yaml
+++ b/apps/nextcloud/cronjob.yaml
@@ -24,7 +24,7 @@ spec:
           containers:
             - name: maint-on
               image: registry.k8s.io/kubectl:v1.33.3
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: Always
               command:
                 - kubectl
                 - exec
@@ -77,7 +77,7 @@ spec:
           containers:
             - name: maint-on
               image: registry.k8s.io/kubectl:v1.33.3
-              imagePullPolicy: IfNotPresent
+              imagePullPolicy: Always
               command:
                 - kubectl
                 - exec

--- a/apps/nextcloud/nextcloud-setup-job.yaml
+++ b/apps/nextcloud/nextcloud-setup-job.yaml
@@ -11,7 +11,8 @@ spec:
       serviceAccountName: backup-runner
       containers:
         - name: nextcloud-setup
-          image: bitnami/kubectl:latest
+          image: registry.k8s.io/kubectl:v1.33.3
+          imagePullPolicy: Always
           command:
             - /bin/sh
             - -c

--- a/apps/nextcloud/nextcloud-setup-job.yaml
+++ b/apps/nextcloud/nextcloud-setup-job.yaml
@@ -5,6 +5,7 @@ metadata:
   generateName: nextcloud-setup-
   annotations:
     argocd.argoproj.io/hook: PostSync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
 spec:
   template:
     spec:

--- a/apps/nextcloud/nextcloud-values.yaml
+++ b/apps/nextcloud/nextcloud-values.yaml
@@ -260,7 +260,7 @@ cronjob:
     limits:
       cpu: 350m
       memory: 1Gi
-      ephemeral-storage: 500Mi
+      ephemeral-storage: 2Gi
 service:
   type: ClusterIP
   port: 8080
@@ -449,10 +449,10 @@ metrics:
   ## Metrics exporter resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
   ##
-  resources:
-    requests:
-    memory: 50Mi
-    cpu: 50m
+  # resources:
+  #   requests:
+  #   memory: 50Mi
+  #   cpu: 50m
   limits:
     memory: 500Mi
     cpu: 500m
@@ -487,7 +487,7 @@ metrics:
     runAsUser: 10000
     runAsGroup: 10000
     runAsNonRoot: true
-    fsGroup: 10000
+    # fsGroup: 10000
     allowPrivilegeEscalation: false
     capabilities:
       drop:


### PR DESCRIPTION
**Décrire le pull-request**

Currently nextcloud pods are being evicted with 'Evicted : Container nextcloud-cron exceeded its local ephemeral storage limit "500Mi"'. 

- I'm also pushing a replacement I had for the cronjobs that are making use of bitnami
- Added postsync policy to delete any previous PostSync Job. Its currently polluting the namespace : 
```bash
kubectl get all -n nextcloud                                    
NAME                                              READY   STATUS                   RESTARTS         AGE
pod/collabora-collabora-online-74564c7f4f-67tdl   1/1     Running                  2 (41d ago)      41d
pod/collabora-collabora-online-74564c7f4f-xbkzt   1/1     Running                  0                41d
pod/disable-maintenance-29310200-hdp96            0/1     Completed                0                29h
pod/enable-maintenance-29310150-drnds             0/1     Completed                0                30h
pod/nextcloud-555fd5956d-888cw                    0/2     ContainerStatusUnknown   4 (37h ago)      11d
pod/nextcloud-555fd5956d-m4w28                    2/2     Running                  0                10h
pod/nextcloud-metrics-7f7d97785f-wmrpd            1/1     Running                  0                41d
pod/nextcloud-redis-master-0                      1/1     Running                  2 (8d ago)       41d
pod/nextcloud-redis-replicas-0                    1/1     Running                  3 (8d ago)       41d
pod/nextcloud-redis-replicas-1                    1/1     Running                  8 (8d ago)       41d
pod/nextcloud-redis-replicas-2                    1/1     Running                  35 (8d ago)      49d
pod/nextcloud-setup--postsync-1754436403-k8bnr    0/1     Completed                0                49d
pod/nextcloud-setup--postsync-1754436722-vtt4d    0/1     Completed                0                49d
pod/nextcloud-setup--postsync-1754532100-cpl79    0/1     Completed                0                48d
pod/nextcloud-setup--postsync-1754682885-zmn2j    0/1     Completed                0                46d
pod/nextcloud-setup--postsync-1754759037-brmd8    0/1     Completed                0                45d
pod/nextcloud-setup--postsync-1755038033-sbjmd    0/1     Completed                0                42d
pod/nextcloud-setup--postsync-1755038453-lxfsv    0/1     Completed                0                42d
pod/nextcloud-setup--postsync-1755300273-974jk    0/1     Completed                0                39d
pod/nextcloud-setup--postsync-1755866858-l9462    0/1     Completed                0                33d
pod/nextcloud-setup--postsync-1756259870-r5zbt    0/1     Completed                0                28d
pod/nextcloud-setup--postsync-1756318757-lqcmh    0/1     Completed                0                27d
pod/nextcloud-setup--postsync-1756321529-2nzxl    0/1     Completed                0                27d
pod/nextcloud-setup--postsync-1756325194-5t2dp    0/1     Completed                0                27d
pod/nextcloud-setup--postsync-1756327350-k26s6    0/1     Completed                0                27d
pod/nextcloud-setup--postsync-1756331862-v6nst    0/1     Completed                0                27d
pod/nextcloud-setup--postsync-1756392555-vsvq9    0/1     Completed                0                26d
pod/nextcloud-setup--postsync-1756393095-8qg8j    0/1     Completed                0                26d
pod/nextcloud-setup--postsync-1756394640-jm4gh    0/1     Completed                0                26d
pod/nextcloud-setup--postsync-1756395796-g56gq    0/1     Completed                0                26d
pod/nextcloud-setup--postsync-1756396697-q2v4b    0/1     Completed                0                26d
pod/nextcloud-setup--postsync-1756397235-mflng    0/1     Completed                0                26d
pod/nextcloud-setup--postsync-1756397575-4t9hl    0/1     Completed                0                26d
pod/nextcloud-setup--postsync-1756401195-2pldw    0/1     Completed                0                26d
pod/nextcloud-setup--postsync-1757547884-n7q62    0/1     Completed                0                13d
pod/nextcloud-setup--postsync-1757548520-qglc4    0/1     Completed                0                13d
pod/nextcloud-setup--postsync-1757549060-mmq57    0/1     Completed                0                13d
pod/nextcloud-setup--postsync-1757558586-cz86b    0/1     Completed                0                13d
pod/nextcloud-setup--postsync-1757693916-4km97    0/1     Completed                0                11d
pod/nextcloud-setup--postsync-1757694041-vssnn    0/1     Completed                0                11d
pod/nextcloud-setup--postsync-1757716774-gp4p5    0/1     Completed                0                11d
pod/nextcloud-setup--postsync-1758221045-bgnlf    0/1     Completed                0                5d18h
pod/nextcloud-setup--postsync-1758316585-f9xtp    0/1     Completed                0                4d15h
pod/nextcloud-setup--postsync-1758318168-p78v8    0/1     Completed                0                4d15h
pod/nextcloud-setup--postsync-1758324502-w8xnn    0/1     Completed                0                4d13h
pod/nextcloud-setup--postsync-1758507437-9z9ql    0/1     Completed                0                2d10h
pod/nextcloud-setup--postsync-1758507586-5sglg    0/1     Completed                0                2d10h
pod/nextcloud-setup--postsync-1758510953-wjnrl    0/1     Completed                0                2d9h
pod/nextcloud-setup--postsync-1758511300-dcslm    0/1     Completed                0                2d9h
pod/nextcloud-setup--postsync-1758511398-s6jjq    0/1     Completed                0                2d9h
pod/nextcloud-setup--postsync-1758511493-4cbng    0/1     Completed                0                2d9h
```

**Vérification**
Veuillez cocher les cases suivantes pour confirmer que vous avez effectué les vérifications nécessaires avant de soumettre le pull-request :

- [ ] J'ai vérifié que le code fonctionne correctement.
- [ ] J'ai vérifié que le code respecte l'architecture du projet.

**Documentation**
- [ ] J'ai mis à jour la documentation si nécessaire sinon j'ai ouvert un issue pour la mettre à jour.