### PR TITLE
feat(authentik): cutover to CloudNativePG, disable bundled PostgreSQL

### DIFF
--- a/apps/authentik/helm/values.yaml
+++ b/apps/authentik/helm/values.yaml
@@ -68,23 +68,17 @@ global:
           name: authentik-secrets
           key: AUTHENTIK_BOOTSTRAP_PASSWORD
 
+    - name: AUTHENTIK_POSTGRESQL__HOST
+      value: postgresql-authentik-rw
+    - name: AUTHENTIK_POSTGRESQL__NAME
+      value: authentik
+    - name: AUTHENTIK_POSTGRESQL__USER
+      value: authentik
     - name: AUTHENTIK_POSTGRESQL__PASSWORD
       valueFrom:
         secretKeyRef:
-          name: authentik-secrets
-          key: AUTHENTIK_POSTGRES_PASSWORD
+          name: authentik-cnpg-app
+          key: password
 
 postgresql:
-  enabled: true
-  image:
-    registry: docker.io
-    repository: library/postgres
-    tag: "15-bookworm"
-  auth:
-    existingSecret: authentik-secrets
-    secretKeys:
-      adminPasswordKey: AUTHENTIK_POSTGRES_PASSWORD
-      userPasswordKey: AUTHENTIK_POSTGRES_PASSWORD
-  persistence:
-    enabled: true
-    storageClass: cephfs
+  enabled: false


### PR DESCRIPTION
Phase 2 of the CNPG migration. Data was restored and validated on postgresql-authentik (285 users, 24 apps, 19 flows). Authentik now points to postgresql-authentik-rw via the authentik-cnpg-app secret.

**Décrire le pull-request**
Une petite description claire et concise des modifications apportées.

**Vérification**
Veuillez cocher les cases suivantes pour confirmer que vous avez effectué les vérifications nécessaires avant de soumettre le pull-request :

- [ ] J'ai vérifié que le code fonctionne correctement.
- [ ] J'ai vérifié que le code respecte l'architecture du projet.

**Documentation**
- [ ] J'ai mis à jour la documentation si nécessaire sinon j'ai ouvert un issue pour la mettre à jour.