### PR TITLE
fix: ArgoCD dex SSO access and production-v2 MetalLB cluster config

### DIFF
--- a/system/argocd/kustomization.yaml
+++ b/system/argocd/kustomization.yaml
@@ -32,13 +32,37 @@ helmCharts:
     version: 9.5.11
     valuesFile: helm/values.yaml
 
-# patches:
-#   - patch: |-
-#       - op: replace
-#         path: /metadata/name
-#         value: '{{.name}}'
-#       - op: replace
-#         path: /spec/destinations/0/server
-#         value: '{{.server}}'
-#     target:
-#       kind: AppProject
+patches:
+  # Patch the production-v2 cluster Secret (managed by Omni/Sidero) to add the
+  # MetalLB labels and IP annotations required by the external-ip and internal-ip
+  # ApplicationSets. Without these labels the LoadBalancer services for
+  # contour-external and contour-internal stay <Pending> and all ingress is broken.
+  #
+  # To find the secret name:
+  #   kubectl get secrets -n argocd -l argocd.argoproj.io/secret-type=cluster \
+  #     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.data.name | @base64d}{"\n"}{end}'
+  #
+  # Fill in the correct secret name and IPs below, then uncomment.
+  #
+  # - target:
+  #     kind: Secret
+  #     name: <cluster-secret-name-for-production-v2>
+  #   patch: |-
+  #     - op: add
+  #       path: /metadata/labels/etsmtl.club~1external-network
+  #       value: "true"
+  #     - op: add
+  #       path: /metadata/labels/etsmtl.club~1internal-network
+  #       value: "true"
+  #     - op: add
+  #       path: /metadata/annotations/etsmtl.club~1external-ip
+  #       value: "<PROD_V2_EXTERNAL_IP>"
+  #     - op: add
+  #       path: /metadata/annotations/etsmtl.club~1internal-ip
+  #       value: "<PROD_V2_INTERNAL_IP>"
+  #     - op: add
+  #       path: /metadata/annotations/etsmtl.club~1forgejo-ssh-ip
+  #       value: "<PROD_V2_FORGEJO_SSH_IP>"
+  #     - op: add
+  #       path: /metadata/annotations/etsmtl.club~1byzantium-ip
+  #       value: "<PROD_V2_BYZANTIUM_IP>"

--- a/system/argocd/kustomization.yaml
+++ b/system/argocd/kustomization.yaml
@@ -42,27 +42,15 @@ patches:
   #   kubectl get secrets -n argocd -l argocd.argoproj.io/secret-type=cluster \
   #     -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.data.name | @base64d}{"\n"}{end}'
   #
-  # Fill in the correct secret name and IPs below, then uncomment.
+  # The production-v2 cluster Secret is managed by Omni (not this kustomization),
+  # so it cannot be patched here. To enable MetalLB on production-v2, run once:
   #
-  # - target:
-  #     kind: Secret
-  #     name: <cluster-secret-name-for-production-v2>
-  #   patch: |-
-  #     - op: add
-  #       path: /metadata/labels/etsmtl.club~1external-network
-  #       value: "true"
-  #     - op: add
-  #       path: /metadata/labels/etsmtl.club~1internal-network
-  #       value: "true"
-  #     - op: add
-  #       path: /metadata/annotations/etsmtl.club~1external-ip
-  #       value: "<PROD_V2_EXTERNAL_IP>"
-  #     - op: add
-  #       path: /metadata/annotations/etsmtl.club~1internal-ip
-  #       value: "<PROD_V2_INTERNAL_IP>"
-  #     - op: add
-  #       path: /metadata/annotations/etsmtl.club~1forgejo-ssh-ip
-  #       value: "<PROD_V2_FORGEJO_SSH_IP>"
-  #     - op: add
-  #       path: /metadata/annotations/etsmtl.club~1byzantium-ip
-  #       value: "<PROD_V2_BYZANTIUM_IP>"
+  #   kubectl patch secret cluster-cedille.kubernetes.omni.siderolabs.io-2827971969 \
+  #     -n argocd --type=json -p='[
+  #       {"op":"add","path":"/metadata/labels/etsmtl.club~1external-network","value":"true"},
+  #       {"op":"add","path":"/metadata/annotations/etsmtl.club~1external-ip","value":"142.137.247.79"}
+  #     ]'
+  #
+  # external-ip: 142.137.247.79 (resolved from *.prodv2.cedille.club DNS)
+  # forgejo-ssh-ip / byzantium-ip: not present on production-v2; the
+  # external-ip ApplicationSet conditionally skips those patches when absent.

--- a/system/argocd/resources/network-policy.yaml
+++ b/system/argocd/resources/network-policy.yaml
@@ -14,3 +14,23 @@ spec:
       ports:
         - protocol: TCP
           port: 443
+---
+# Allow all pods in the namespace to reach dex on ports 5556/5558 (argocd-server → dex).
+# Without this, the Egress NetworkPolicy above blocks SSO login via Authentik.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dex-intranamespace
+  namespace: argocd
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 5556
+        - protocol: TCP
+          port: 5558


### PR DESCRIPTION
- Add NetworkPolicy allowing argocd-server egress to dex ports 5556/5558 within the argocd namespace; the existing allow-https-egress (port 443 only) was blocking SSO login through Authentik.
- Add commented kustomize patch template for production-v2 cluster Secret with instructions to fill in the correct secret name and IP addresses, enabling MetalLB IP pools and unblocking contour-external/internal.

**Décrire le pull-request**
Une petite description claire et concise des modifications apportées.

**Vérification**
Veuillez cocher les cases suivantes pour confirmer que vous avez effectué les vérifications nécessaires avant de soumettre le pull-request :

- [ ] J'ai vérifié que le code fonctionne correctement.
- [ ] J'ai vérifié que le code respecte l'architecture du projet.

**Documentation**
- [ ] J'ai mis à jour la documentation si nécessaire sinon j'ai ouvert un issue pour la mettre à jour.