### PR TITLE
feat(metallb): add dedicated IP pools for forgejo and byzantium on k8…

### DIFF
--- a/system/metallb-extra/ip-pools.yaml
+++ b/system/metallb-extra/ip-pools.yaml
@@ -1,0 +1,36 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: forgejo-ip
+  namespace: metallb-system
+spec:
+  addresses:
+    - 142.137.247.76/32
+  serviceAllocation:
+    namespaces:
+      - forgejo
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: byzantium-ip
+  namespace: metallb-system
+spec:
+  addresses:
+    - 142.137.247.78/32
+  serviceAllocation:
+    namespaces:
+      - byzantium-helm
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: extra-ips
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - forgejo-ip
+    - byzantium-ip
+  nodeSelectors:
+    - matchLabels:
+        etsmtl.club/external-network: "true"

--- a/system/metallb-extra/kustomization.yaml
+++ b/system/metallb-extra/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ip-pools.yaml

--- a/system/metallb-extra/metallb-extra.argoapp.yaml
+++ b/system/metallb-extra/metallb-extra.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: metallb-extra-ips
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "-75"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: metallb-system
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared.git
+    path: system/metallb-extra
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
…s-shared

Move forgejo (.76) and byzantium (.78) out of the shared public-ip pool into dedicated pools with per-namespace serviceAllocation. This decouples k8s-shared-specific IPs from the common external-ip ApplicationSet, which now manages only one IP per cluster (preventing MetalLB overlap errors on single-IP clusters like production-v2).

Deploy order: this must land before the k8s-base change that removes forgejo/byzantium from the public-ip pool to avoid a brief outage window.

**Décrire le pull-request**
Une petite description claire et concise des modifications apportées.

**Vérification**
Veuillez cocher les cases suivantes pour confirmer que vous avez effectué les vérifications nécessaires avant de soumettre le pull-request :

- [ ] J'ai vérifié que le code fonctionne correctement.
- [ ] J'ai vérifié que le code respecte l'architecture du projet.

**Documentation**
- [ ] J'ai mis à jour la documentation si nécessaire sinon j'ai ouvert un issue pour la mettre à jour.