### PR TITLE
fix: use ceph-rbd for RWO workloads and cap nextcloud cron runtime

### DIFF
--- a/apps/forgejo/base/valkey.values.yaml
+++ b/apps/forgejo/base/valkey.values.yaml
@@ -36,7 +36,6 @@ service:
 # More info: https://kubernetes.io/docs/concepts/services-networking/network-policies/
 networkPolicy: {}
 
-# TODO USE CEPHFS
 # Persistent storage configuration
 dataStorage:
   # Enable persistent volume claim creation
@@ -48,7 +47,7 @@ dataStorage:
   # Request size (e.g. 5Gi) for dynamically provisioned volume
   requestedSize: "5Gi"
   # Name of the storage class to use
-  className: ""
+  className: "ceph-rbd"
   # Access modes for the PVC (e.g., ReadWriteOnce, ReadWriteMany)
   accessModes:
     - ReadWriteOnce

--- a/apps/forgejo/prod/cnpg.cluster.yaml
+++ b/apps/forgejo/prod/cnpg.cluster.yaml
@@ -13,7 +13,7 @@ spec:
         name: postgresql-forgejo-app
   storage:
     size: 80Gi
-    storageClass: cephfs
+    storageClass: ceph-rbd
   walStorage:
     size: 20Gi
     storageClass: ceph-rbd

--- a/apps/nextcloud/helm/nextcloud-values.yaml
+++ b/apps/nextcloud/helm/nextcloud-values.yaml
@@ -271,6 +271,8 @@ cronjob:
   enabled: true
   type: cronjob
   command: [/cron.sh]
+  cronjob:
+    activeDeadlineSeconds: 3600
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
## Contexte

Le 2026-06-30, `git.etsmtl.club` était down pendant plusieurs heures suite à une cascade de pannes causée par des montages CephFS corrompus sur worker-1. Post-mortem : trois fixes préventifs.

## Changements

### 1. Valkey → `ceph-rbd` (`apps/forgejo/base/valkey.values.yaml`)

Le PVC Valkey utilisait la StorageClass par défaut (`cephfs`) via un `className: ""`. Valkey n'a besoin que de RWO — CephFS est inutile ici et introduit des sessions kernel Ceph pouvant se corrompre. Changé pour `ceph-rbd`.

**Migration requise :** après merge et sync ArgoCD, supprimer le PVC existant `forgejo-cache-valkey` — Valkey le re-créera automatiquement sur RBD.

### 2. CNPG PostgreSQL → `ceph-rbd` (`apps/forgejo/prod/cnpg.cluster.yaml`)

Le `walStorage` était déjà sur `ceph-rbd`; le `storage` (données) était sur `cephfs`. Aligné sur RBD pour éliminer le risque de corruption de globalmount CephFS sur les nœuds PostgreSQL.

**Migration requise :** les PVCs existants (`postgresql-forgejo-1`, `-3`) ne changent pas. Pour migrer, supprimer un PVC à la fois et laisser CNPG re-provisionner depuis le primaire (rolling). Les nouvelles instances (ex: `-4` créée ce matin) utiliseront déjà RBD.

### 3. Nextcloud cron → `activeDeadlineSeconds: 3600` (`apps/nextcloud/helm/nextcloud-values.yaml`)

Le pod `nextcloud-cron` était bloqué en `Terminating` depuis 7 jours, saturant le CSI plugin du nœud. Le chart Nextcloud expose `cronjob.cronjob.activeDeadlineSeconds` pour limiter la durée d'exécution d'un job. Fixé à 1h — si `/cron.sh` dépasse ça, le job est tué automatiquement.

## Test plan

- [ ] Après merge : vérifier ArgoCD sync sans erreur
- [ ] Supprimer PVC `forgejo-cache-valkey` → confirmer re-création sur `ceph-rbd`
- [ ] Confirmer Valkey `1/1 Running` et Forgejo toujours accessible
- [ ] Planifier migration roulante des PVCs CNPG (hors merge bloquant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)