### PR TITLE
fix: nextcloud CNPG to ceph-rbd and fix cron runAsUser

### DIFF
--- a/apps/nextcloud/helm/nextcloud-values.yaml
+++ b/apps/nextcloud/helm/nextcloud-values.yaml
@@ -270,9 +270,13 @@ redis:
 cronjob:
   enabled: true
   type: cronjob
-  command: [/cron.sh]
   cronjob:
     activeDeadlineSeconds: 3600
+    securityContext:
+      runAsUser: 33
+      runAsGroup: 33
+      runAsNonRoot: true
+      readOnlyRootFilesystem: true
   resources:
     requests:
       cpu: 50m
@@ -281,11 +285,6 @@ cronjob:
       cpu: 350m
       memory: 1Gi
       ephemeral-storage: 2Gi
-  securityContext:
-    runAsUser: 33
-    runAsGroup: 33
-    runAsNonRoot: true
-    readOnlyRootFilesystem: true
 service:
   type: ClusterIP
   port: 8080

--- a/apps/nextcloud/resources/postgresql.yaml
+++ b/apps/nextcloud/resources/postgresql.yaml
@@ -14,7 +14,7 @@ spec:
         name: nextcloud-postgresql
   storage:
     size: 105Gi
-    storageClass: cephfs
+    storageClass: ceph-rbd
   walStorage:
     size: 20Gi
     storageClass: ceph-rbd


### PR DESCRIPTION
## Contexte

Suite au post-mortem du 2026-06-30 (voir #289), deux problèmes identifiés sur Nextcloud.

## Changements

### 1. CNPG PostgreSQL → `ceph-rbd` (`apps/nextcloud/resources/postgresql.yaml`)

Même problème que Forgejo (#289) : les PVCs de données PostgreSQL (105Gi) utilisent CephFS alors que l'accès est RWO. Le WAL storage est déjà sur `ceph-rbd`. Alignement du data storage sur RBD pour éliminer le risque de corruption de globalmount CephFS.

**État actuel :** instance 2 avait un checkpoint corrompu (`could not locate a valid checkpoint record`) depuis le 16 juin (224 restarts). Supprimée manuellement — CNPG provisionne l'instance 7 en remplacement (sur cephfs, car ce PR n'était pas encore mergé au moment de l'action).

**Migration requise après merge :** supprimer les PVCs des instances 5 et 6 un à la fois pour que CNPG les reprovisionne sur RBD. Faire un failover avant de migrer le primaire.

### 2. Fix cron `runAsUser` (`apps/nextcloud/helm/nextcloud-values.yaml`)

Le cron Nextcloud échoue depuis ~7 jours avec :
```
Console has to be executed with the user that owns the file config/config.php.
Current user id: 0
Owner id of config.php: 33
```

**Cause racine :** `securityContext` était placé sous `cronjob.securityContext`, qui correspond au mode `type: sidecar`. Pour `type: cronjob`, le bon niveau est `cronjob.cronjob.securityContext`. Le `runAsUser: 33` était ignoré, le pod tournait en root. Nextcloud 33.x a ajouté cette vérification d'ownership.

Également supprimé `cronjob.command: [/cron.sh]` qui était un no-op pour `type: cronjob` (le chart utilise `php cron.php` par défaut dans ce mode).

## Test plan

- [ ] Après merge : vérifier que le prochain pod `nextcloud-cron-XXXXX` passe `Completed` (plus d'erreur user id)
- [ ] Vérifier `kubectl get pod <cron-pod> -o jsonpath='{.spec.securityContext}'` montre `runAsUser: 33`
- [ ] Planifier migration roulante des PVCs CNPG (instances 5 et 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)