### PR TITLE
outline-cedille: move CNPG data volumes to ceph-rbd

### DIFF
--- a/apps/outline-cedille/prod/postgres.yaml
+++ b/apps/outline-cedille/prod/postgres.yaml
@@ -13,7 +13,7 @@ spec:
         name: postgresql-outline-app
   storage:
     size: 26Gi
-    storageClass: cephfs
+    storageClass: ceph-rbd
   # backup:
   #   retentionPolicy: 7d
   # volumeSnapshot:


### PR DESCRIPTION
## Summary
- 2/3 CNPG replicas for outline-cedille (`postgresql-outline-cedille-1`/`-2`) are stuck in CrashLoopBackOff for days with `permission denied` on `pgdata` and WAL-archiving failures — a known CephFS issue for Postgres data volumes.
- forgejo's cluster already hit the same problem and was migrated to `ceph-rbd` for its data volume (confirmed live: `postgresql-forgejo-5/6/7` PVCs are on `ceph-rbd`), so apply the same fix here.
- Changes `storageClass: cephfs` -> `storageClass: ceph-rbd` in `apps/outline-cedille/prod/postgres.yaml` for the main data volume.

## Test plan
- [x] Applied directly to the live k8s-shared cluster to restore the two down replicas (recreated their PVCs on `ceph-rbd`, resynced via streaming replication from the healthy primary)
- [ ] Confirm cluster reaches 3/3 Ready
- [ ] ArgoCD will pick this manifest up on sync (selfHeal is off, so it won't fight the already-applied live fix)