### PR TITLE
Add lanets club shared ingress wildcard certificate

### DIFF
--- a/apps/clubs/lanets/kustomization.yaml
+++ b/apps/clubs/lanets/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: lanets-v1
+  namespace: lanets-shared
+
+resources:
+  - resources/certificate.yaml

--- a/apps/clubs/lanets/lanets-shared.argoapp.yaml
+++ b/apps/clubs/lanets/lanets-shared.argoapp.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: lanets-shared
+  namespace: argocd
+spec:
+  destination:
+    namespace: lanets-shared
+    server: https://kubernetes.default.svc
+  project: lanets
+  source:
+    path: apps/clubs/lanets
+    repoURL: https://github.com/ClubCedille/k8s-shared.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/clubs/lanets/resources/certificate.yaml
+++ b/apps/clubs/lanets/resources/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: lanets-wildcard
+spec:
+  secretName: lanets-wildcard-tls
+  issuerRef:
+    name: letsencrypt-lanets
+    kind: ClusterIssuer
+  commonName: lanets.ca
+  dnsNames:
+    - lanets.ca
+    - "*.lanets.ca"


### PR DESCRIPTION
## Summary
- Onboards the LAN ETS (`lanets`) club onto the shared cluster's GitOps flow
- New ArgoCD Application `lanets-shared` (project `lanets`, namespace `lanets-shared`) deploying a `cert-manager` `Certificate` for `lanets.ca` + `*.lanets.ca`
- Pairs with the new `letsencrypt-lanets` `ClusterIssuer` added in `k8s-foundation` (ClubCedille/k8s-foundation#TBD)
- Wildcard secret `lanets-wildcard-tls` is reusable by future club apps' `HTTPProxy` resources without per-subdomain certs

## Context
- Main ingress (`contour-external-envoy`) public IP is `142.137.247.75` — DNS A records for `lanets.ca`/`*.lanets.ca` have already been pointed there
- Cloudflare API token (`cloudflare-token` secret, already used by `letsencrypt-prod`) has been widened to also cover the `lanets.ca` zone for DNS01 challenges

## Test plan
- [ ] Confirm `letsencrypt-lanets` ClusterIssuer is `Ready` after the k8s-foundation PR syncs
- [ ] Confirm ArgoCD syncs `lanets-shared` Application successfully (namespace `lanets-shared` created)
- [ ] Confirm `Certificate/lanets-wildcard` reaches `Ready` and `lanets-wildcard-tls` secret is populated
- [ ] `openssl s_client -connect lanets.ca:443 -servername lanets.ca` (once an app uses the cert) shows the wildcard cert