### PR TITLE
Add lanets catch-all HTTPProxy for HTTP->HTTPS redirect

### DIFF
--- a/apps/clubs/lanets/kustomization.yaml
+++ b/apps/clubs/lanets/kustomization.yaml
@@ -6,3 +6,4 @@ metadata:
 
 resources:
   - resources/certificate.yaml
+  - resources/catchall-httpproxy.yaml

--- a/apps/clubs/lanets/resources/catchall-httpproxy.yaml
+++ b/apps/clubs/lanets/resources/catchall-httpproxy.yaml
@@ -1,0 +1,29 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: lanets-catchall-apex
+spec:
+  virtualhost:
+    fqdn: lanets.ca
+    tls:
+      secretName: lanets-wildcard-tls
+  routes:
+    - conditions:
+        - prefix: /
+      directResponsePolicy:
+        statusCode: 404
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: lanets-catchall-wildcard
+spec:
+  virtualhost:
+    fqdn: "*.lanets.ca"
+    tls:
+      secretName: lanets-wildcard-tls
+  routes:
+    - conditions:
+        - prefix: /
+      directResponsePolicy:
+        statusCode: 404


### PR DESCRIPTION
## Summary
- Registers `lanets.ca` (apex) and `*.lanets.ca` (wildcard) as TLS-terminated Contour vhosts, backed by the shared wildcard cert (`lanets-wildcard-tls`) from #309
- Each route uses `directResponsePolicy` (404, no backend needed) — the point isn't to serve content, it's to make Contour's default HTTP->HTTPS redirect apply domain-wide, not just to hosts that already have their own app-specific HTTPProxy/Ingress (e.g. `xibo.lanets.ca`)
- Exact-match vhosts (any future app's `<sub>.lanets.ca` HTTPProxy or Ingress) still win over the `*.lanets.ca` wildcard per Envoy's domain matching, so this is purely a fallback and won't shadow real apps

## Context
Verified Contour's default behavior first: any vhost with TLS configured already gets an automatic 301 HTTP->HTTPS redirect (confirmed against `nextcloud.etsmtl.club`/`argocd.etsmtl.club`). The gap was that hosts under `lanets.ca` with no matching vhost at all (bare apex, or any subdomain before an app claims it) fell through to a plain 404 on port 80 with no redirect. This PR closes that gap.

## Test plan
- [ ] `curl -I http://lanets.ca` → `301` to `https://lanets.ca/`
- [ ] `curl -I http://randomsub.lanets.ca` → `301` to `https://randomsub.lanets.ca/`
- [ ] `curl -I http://xibo.lanets.ca` still redirects via its own HTTPProxy/Ingress (unaffected by this change)