### PR TITLE
feat(coder): bootstrap Coder deployment on k8s-shared

### DIFF
--- a/.github/workflows/apply-tf.yml
+++ b/.github/workflows/apply-tf.yml
@@ -12,6 +12,7 @@ on:
           - auth-only
           - nodered
           - outline
+          - coder
           - all
   push:
     branches:
@@ -20,6 +21,7 @@ on:
       - '.github/workflows/apply-tf.yml'
       - 'terraform/outline/authentik-vault/**'
       - 'terraform/nodered/authentik-vault/**'
+      - 'terraform/coder/authentik-vault/**'
 
 jobs:
   terraform_apply:
@@ -55,18 +57,27 @@ jobs:
               nodered)
                 echo "outline=false" >> "$GITHUB_OUTPUT"
                 echo "nodered=true" >> "$GITHUB_OUTPUT"
+                echo "coder=false" >> "$GITHUB_OUTPUT"
                 ;;
               outline)
                 echo "outline=true" >> "$GITHUB_OUTPUT"
                 echo "nodered=false" >> "$GITHUB_OUTPUT"
+                echo "coder=false" >> "$GITHUB_OUTPUT"
+                ;;
+              coder)
+                echo "outline=false" >> "$GITHUB_OUTPUT"
+                echo "nodered=false" >> "$GITHUB_OUTPUT"
+                echo "coder=true" >> "$GITHUB_OUTPUT"
                 ;;
               all)
                 echo "outline=true" >> "$GITHUB_OUTPUT"
                 echo "nodered=true" >> "$GITHUB_OUTPUT"
+                echo "coder=true" >> "$GITHUB_OUTPUT"
                 ;;
               auth-only)
                 echo "outline=false" >> "$GITHUB_OUTPUT"
                 echo "nodered=false" >> "$GITHUB_OUTPUT"
+                echo "coder=false" >> "$GITHUB_OUTPUT"
                 ;;
               *)
                 echo "Unsupported module: $REQUESTED_MODULE" >&2
@@ -93,6 +104,12 @@ jobs:
             echo "nodered=true" >> "$GITHUB_OUTPUT"
           else
             echo "nodered=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -q '^terraform/coder/authentik-vault/' /tmp/changed-files; then
+            echo "coder=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "coder=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Authenticate to Vault with GitHub OIDC
@@ -125,6 +142,17 @@ jobs:
           TF_VAR_AUTHENTIK_API_TOKEN: ${{ secrets.AUTHENTIK_TOKEN }}
         run: |
           cd terraform/nodered/authentik-vault
+
+          tofu init
+          tofu apply -auto-approve
+
+      - name: Tofu Init & Apply Coder
+        if: steps.changes.outputs.coder == 'true'
+        env:
+          TF_IN_AUTOMATION: true
+          TF_VAR_AUTHENTIK_API_TOKEN: ${{ secrets.AUTHENTIK_TOKEN }}
+        run: |
+          cd terraform/coder/authentik-vault
 
           tofu init
           tofu apply -auto-approve

--- a/apps/coder/coder.argoapp.yaml
+++ b/apps/coder/coder.argoapp.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: coder
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: coder
+  project: k8s-shared
+  sources:
+    - chart: coder
+      helm:
+        releaseName: coder
+        valueFiles:
+          - $values/apps/coder/helm/values.yaml
+      repoURL: https://helm.coder.com/v2
+      targetRevision: 2.35.3
+    - repoURL: "https://github.com/ClubCedille/k8s-shared.git"
+      targetRevision: HEAD
+      ref: values
+    - repoURL: "https://github.com/ClubCedille/k8s-shared.git"
+      path: apps/coder/resources
+      targetRevision: HEAD
+  syncPolicy:
+    automated:
+      selfHeal: true
+      prune: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/coder/coder.md
+++ b/apps/coder/coder.md
@@ -1,0 +1,61 @@
+# Coder
+
+Environnements de dev distants, déployés dans le namespace `coder` (control
+plane) + `coder-workspaces` (pods des workspaces).
+
+- URL : https://coder.etsmtl.club
+- Wildcard (apps/ports de workspace) : `*.coder.etsmtl.club`
+
+## Auth
+
+OIDC via Authentik, provider provisionné par
+`terraform/coder/authentik-vault` (appliqué par `.github/workflows/apply-tf.yml`,
+module `coder`). Le secret `coder-oidc-secret` (kv Vault
+`kv/data/coder/default/coder-oidc-secret`) est synchronisé dans le namespace
+`coder` par `apps/coder/resources/vault.yaml`.
+
+**Group sync (OSS)** : le claim `groups` (scope mapping custom `coder-scope-groups`
+dans le module terraform) réplique les groupes Authentik en groupes Coder
+(`CODER_OIDC_GROUP_AUTO_CREATE=true`).
+
+**Pas de role sync** : la promotion automatique groupe→rôle site (`Owner`,
+`Auditor`, `Template Admin`) est une fonctionnalité Premium/Enterprise, absente
+de Coder Community. Les rôles admin sont assignés **manuellement** après le
+premier login OIDC de la personne :
+
+```sh
+coder users list
+coder users edit-roles <username> --site-role owner
+```
+
+## Rotation du secret OIDC
+
+Le client secret est généré par `random_password` dans
+`terraform/coder/authentik-vault/main.tf`. Pour le faire tourner : `terraform
+taint`/re-`apply` la ressource `random_password.coder_client_secret` (ou
+relancer le workflow `apply-tf.yml` après un changement du module), ce qui
+régénère le secret côté Authentik et le réécrit dans Vault. Le
+`VaultStaticSecret` re-synchronise automatiquement le secret Kubernetes.
+
+## Base de données
+
+CNPG (`apps/coder/resources/postgres.yaml`), storageClass `ceph-rbd` (pas
+`cephfs`), secret applicatif auto-généré `coder-pg-app` (clé `uri` utilisée
+directement comme `CODER_PG_CONNECTION_URL`). Backup quotidien vers B2 via
+barman-cloud.
+
+## Workspaces
+
+Provisionner via Kubernetes (pods dans `coder-workspaces`, isolé du control
+plane par RBAC scopée + `ResourceQuota`/`LimitRange`, voir
+`apps/coder/resources/workspaces-namespace.yaml`).
+
+Template par défaut : `apps/coder/templates/kubernetes/main.tf`. Pas géré par
+ArgoCD -- à pousser manuellement (ou via CI) :
+
+```sh
+coder templates push kubernetes -d apps/coder/templates/kubernetes
+```
+
+Home dir persistant par workspace sur `ceph-rbd` (taille configurable au
+provisioning, paramètre `home_disk_size`).

--- a/apps/coder/helm/values.yaml
+++ b/apps/coder/helm/values.yaml
@@ -1,0 +1,61 @@
+coder:
+  image:
+    tag: "2.35.3"
+
+  replicaCount: 1
+
+  # Terminaison TLS faite par Contour (HTTPProxy) devant Coder.
+  tls:
+    secretNames: []
+
+  service:
+    enable: true
+    type: ClusterIP
+
+  # Pas d'Ingress natif : le routage est fait par apps/coder/resources/httpproxy.yaml
+  # (virtualhost principal + wildcard pour l'accès direct aux apps de workspace).
+  ingress:
+    enable: false
+
+  env:
+    - name: CODER_ACCESS_URL
+      value: "https://coder.etsmtl.club"
+    - name: CODER_WILDCARD_ACCESS_URL
+      value: "*.coder.etsmtl.club"
+
+    # OIDC (Authentik) -- voir terraform/coder/authentik-vault
+    - name: CODER_OIDC_ISSUER_URL
+      value: "https://auth.etsmtl.club/application/o/coder/"
+    - name: CODER_OIDC_CLIENT_ID
+      valueFrom:
+        secretKeyRef:
+          name: coder-oidc-secret
+          key: OIDC_CLIENT_ID
+    - name: CODER_OIDC_CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: coder-oidc-secret
+          key: OIDC_CLIENT_SECRET
+    - name: CODER_OIDC_SCOPES
+      value: "openid,profile,email,groups"
+    - name: CODER_OIDC_SIGN_IN_TEXT
+      value: "Se connecter avec Authentik"
+    - name: CODER_OIDC_ALLOW_SIGNUPS
+      value: "true"
+
+    # Group sync (OSS) : les groupes Authentik (claim `groups`, voir le scope
+    # mapping custom dans terraform/coder/authentik-vault) sont répliqués en
+    # groupes Coder. Pas de role sync (Owner/Auditor/Template Admin) --
+    # fonctionnalité Premium/Enterprise, non disponible en Community.
+    # Les rôles site restent assignés manuellement (voir docs/coder-deployment.md).
+    - name: CODER_OIDC_GROUP_FIELD
+      value: "groups"
+    - name: CODER_OIDC_GROUP_AUTO_CREATE
+      value: "true"
+
+    # Base de données (CNPG, voir apps/coder/resources/postgres.yaml)
+    - name: CODER_PG_CONNECTION_URL
+      valueFrom:
+        secretKeyRef:
+          name: coder-pg-app
+          key: uri

--- a/apps/coder/helm/values.yaml
+++ b/apps/coder/helm/values.yaml
@@ -17,6 +17,16 @@ coder:
   ingress:
     enable: false
 
+  # Les workspaces tournent dans le namespace dédié `coder-workspaces` (voir
+  # apps/coder/resources/workspaces-namespace.yaml), pas dans le namespace du
+  # control plane -- on retire donc les permissions par défaut ici.
+  serviceAccount:
+    workspacePerms: false
+    workspaceNamespaces:
+      - name: coder-workspaces
+        workspacePerms: true
+        enableDeployments: false
+
   env:
     - name: CODER_ACCESS_URL
       value: "https://coder.etsmtl.club"

--- a/apps/coder/resources/certificate.yaml
+++ b/apps/coder/resources/certificate.yaml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: coder-tls
+spec:
+  secretName: coder-tls
+  issuerRef:
+    name: letsencrypt-etsmtl
+    kind: ClusterIssuer
+  commonName: coder.etsmtl.club
+  dnsNames:
+    - coder.etsmtl.club
+    - "*.coder.etsmtl.club"

--- a/apps/coder/resources/httpproxy.yaml
+++ b/apps/coder/resources/httpproxy.yaml
@@ -1,0 +1,43 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: coder
+spec:
+  virtualhost:
+    fqdn: coder.etsmtl.club
+    tls:
+      secretName: coder-tls
+      minimumProtocolVersion: "1.3"
+  routes:
+    - conditions:
+        - prefix: /
+      enableWebsockets: true
+      services:
+        - name: coder
+          port: 80
+      timeoutPolicy:
+        idle: 600s
+        response: 600s
+---
+# Route wildcard pour l'accès direct aux apps/ports des workspaces
+# (CODER_WILDCARD_ACCESS_URL) sans passer par `coder port-forward`.
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: coder-wildcard
+spec:
+  virtualhost:
+    fqdn: "*.coder.etsmtl.club"
+    tls:
+      secretName: coder-tls
+      minimumProtocolVersion: "1.3"
+  routes:
+    - conditions:
+        - prefix: /
+      enableWebsockets: true
+      services:
+        - name: coder
+          port: 80
+      timeoutPolicy:
+        idle: 600s
+        response: 600s

--- a/apps/coder/resources/postgres.yaml
+++ b/apps/coder/resources/postgres.yaml
@@ -1,0 +1,64 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: postgresql-coder
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.2
+  instances: 1
+  bootstrap:
+    initdb:
+      database: coder
+      owner: coder
+      secret:
+        name: coder-pg-app
+  storage:
+    size: 10Gi
+    storageClass: ceph-rbd
+  plugins:
+    - name: barman-cloud.cloudnative-pg.io
+      isWALArchiver: true
+      parameters:
+        barmanObjectName: cnpg-coder-b2
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: cnpg-backup-schedule
+spec:
+  schedule: "0 20 6 * * * "
+  backupOwnerReference: self
+  cluster:
+    name: postgresql-coder
+  method: plugin
+  pluginConfiguration:
+    name: barman-cloud.cloudnative-pg.io
+---
+apiVersion: barmancloud.cnpg.io/v1
+kind: ObjectStore
+metadata:
+  name: cnpg-coder-b2
+spec:
+  configuration:
+    destinationPath: s3://k8s-shared-bucket/postgresql-coder
+    endpointURL: https://s3.ca-east-006.backblazeb2.com
+    s3Credentials:
+      accessKeyId:
+        name: b2-creds
+        key: ACCESS_KEY_ID
+      secretAccessKey:
+        name: b2-creds
+        key: ACCESS_SECRET_KEY
+    wal:
+      compression: gzip
+      encryption: AES256
+    data:
+      compression: gzip
+      encryption: AES256
+      jobs: 2
+  retentionPolicy: 30d
+  instanceSidecarConfiguration:
+    env:
+      - name: AWS_REQUEST_CHECKSUM_CALCULATION
+        value: when_required
+      - name: AWS_RESPONSE_CHECKSUM_VALIDATION
+        value: when_required

--- a/apps/coder/resources/vault.yaml
+++ b/apps/coder/resources/vault.yaml
@@ -1,0 +1,38 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: coder-auth
+spec:
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    audiences:
+      - vault
+    role: secret-reader
+    serviceAccount: default
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: coder-oidc-secret
+spec:
+  vaultAuthRef: coder-auth
+  type: kv-v1
+  mount: kv
+  path: data/coder/default/coder-oidc-secret
+  destination:
+    name: coder-oidc-secret
+    create: true
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: b2-creds
+spec:
+  vaultAuthRef: coder-auth
+  type: kv-v1
+  mount: kv-system
+  path: default_passwords/b2-creds
+  destination:
+    name: b2-creds
+    create: true

--- a/apps/coder/resources/workspaces-namespace.yaml
+++ b/apps/coder/resources/workspaces-namespace.yaml
@@ -1,0 +1,36 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coder-workspaces
+---
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: coder-workspaces-quota
+  namespace: coder-workspaces
+spec:
+  hard:
+    pods: "20"
+    requests.cpu: "20"
+    requests.memory: 40Gi
+    limits.cpu: "40"
+    limits.memory: 80Gi
+    requests.storage: 200Gi
+---
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: coder-workspaces-limits
+  namespace: coder-workspaces
+spec:
+  limits:
+    - type: Container
+      default:
+        cpu: "2"
+        memory: 4Gi
+      defaultRequest:
+        cpu: "500m"
+        memory: 1Gi
+      max:
+        cpu: "8"
+        memory: 16Gi

--- a/apps/coder/templates/kubernetes/main.tf
+++ b/apps/coder/templates/kubernetes/main.tf
@@ -101,7 +101,6 @@ data "coder_parameter" "image" {
 resource "coder_agent" "main" {
   os             = "linux"
   arch           = "amd64"
-  dir            = "/home/coder"
   startup_script = <<-EOT
     set -e
     if [ ! -f "$${HOME}/.init_done" ]; then

--- a/apps/coder/templates/kubernetes/main.tf
+++ b/apps/coder/templates/kubernetes/main.tf
@@ -9,6 +9,7 @@
 # coder.serviceAccount.workspaceNamespaces dans apps/coder/helm/values.yaml).
 
 terraform {
+  required_version = ">=1.14"
   required_providers {
     coder = {
       source  = "coder/coder"
@@ -175,11 +176,11 @@ resource "kubernetes_pod" "main" {
 
       resources {
         requests = {
-          cpu    = "${data.coder_parameter.cpu.value}"
+          cpu    = data.coder_parameter.cpu.value
           memory = "${data.coder_parameter.memory.value}Gi"
         }
         limits = {
-          cpu    = "${data.coder_parameter.cpu.value}"
+          cpu    = data.coder_parameter.cpu.value
           memory = "${data.coder_parameter.memory.value}Gi"
         }
       }

--- a/apps/coder/templates/kubernetes/main.tf
+++ b/apps/coder/templates/kubernetes/main.tf
@@ -1,0 +1,201 @@
+# Template Coder "kubernetes" -- provisionne un workspace de dev sous forme de
+# pod dans le namespace `coder-workspaces` du cluster k8s-shared.
+#
+# Poussé dans Coder avec :
+#   coder templates push kubernetes -d apps/coder/templates/kubernetes
+#
+# Tourne à l'intérieur du pod coderd : la config kubernetes provider utilise
+# donc le ServiceAccount in-cluster (voir la Role/RoleBinding créées par
+# coder.serviceAccount.workspaceNamespaces dans apps/coder/helm/values.yaml).
+
+terraform {
+  required_providers {
+    coder = {
+      source  = "coder/coder"
+      version = "~> 2.9"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.35"
+    }
+  }
+}
+
+locals {
+  namespace = "coder-workspaces"
+}
+
+provider "kubernetes" {
+  config_path = null # in-cluster config
+}
+
+data "coder_workspace" "me" {}
+data "coder_workspace_owner" "me" {}
+
+data "coder_parameter" "cpu" {
+  name         = "cpu"
+  display_name = "CPU"
+  description  = "Nombre de coeurs CPU."
+  type         = "number"
+  default      = "2"
+  mutable      = true
+  option {
+    name  = "2 vCPU"
+    value = "2"
+  }
+  option {
+    name  = "4 vCPU"
+    value = "4"
+  }
+  option {
+    name  = "8 vCPU"
+    value = "8"
+  }
+}
+
+data "coder_parameter" "memory" {
+  name         = "memory"
+  display_name = "Mémoire (Gi)"
+  type         = "number"
+  default      = "4"
+  mutable      = true
+  option {
+    name  = "4 Gi"
+    value = "4"
+  }
+  option {
+    name  = "8 Gi"
+    value = "8"
+  }
+  option {
+    name  = "16 Gi"
+    value = "16"
+  }
+}
+
+data "coder_parameter" "home_disk_size" {
+  name         = "home_disk_size"
+  display_name = "Taille du disque (Gi)"
+  description  = "Persiste entre les redémarrages du workspace (ceph-rbd)."
+  type         = "number"
+  default      = "10"
+  mutable      = false
+}
+
+data "coder_parameter" "image" {
+  name         = "image"
+  display_name = "Image de base"
+  type         = "string"
+  default      = "docker.io/codercom/enterprise-base:ubuntu"
+  mutable      = true
+  option {
+    name  = "Ubuntu (base)"
+    value = "docker.io/codercom/enterprise-base:ubuntu"
+  }
+  option {
+    name  = "Node.js"
+    value = "docker.io/codercom/enterprise-node:ubuntu"
+  }
+}
+
+resource "coder_agent" "main" {
+  os             = "linux"
+  arch           = "amd64"
+  dir            = "/home/coder"
+  startup_script = <<-EOT
+    set -e
+    if [ ! -f "$${HOME}/.init_done" ]; then
+      touch "$${HOME}/.init_done"
+    fi
+
+    # code-server pour l'accès web (voir coder_app ci-dessous)
+    curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=/tmp/code-server
+    /tmp/code-server/bin/code-server --auth none --port 13337 >/tmp/code-server.log 2>&1 &
+  EOT
+}
+
+resource "coder_app" "code-server" {
+  agent_id     = coder_agent.main.id
+  slug         = "code-server"
+  display_name = "code-server"
+  url          = "http://localhost:13337/?folder=/home/coder"
+  icon         = "/icon/code.svg"
+  subdomain    = true
+  share        = "owner"
+
+  healthcheck {
+    url       = "http://localhost:13337/healthz"
+    interval  = 5
+    threshold = 6
+  }
+}
+
+resource "kubernetes_persistent_volume_claim" "home" {
+  metadata {
+    name      = "coder-${data.coder_workspace.me.id}-home"
+    namespace = local.namespace
+  }
+  wait_until_bound = false
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "ceph-rbd"
+    resources {
+      requests = {
+        storage = "${data.coder_parameter.home_disk_size.value}Gi"
+      }
+    }
+  }
+}
+
+resource "kubernetes_pod" "main" {
+  count = data.coder_workspace.me.start_count
+  metadata {
+    name      = "coder-${data.coder_workspace_owner.me.name}-${data.coder_workspace.me.name}"
+    namespace = local.namespace
+    labels = {
+      "app.kubernetes.io/part-of" = "coder-workspaces"
+      "coder.owner"               = data.coder_workspace_owner.me.name
+      "coder.workspace"           = data.coder_workspace.me.name
+    }
+  }
+  spec {
+    security_context {
+      run_as_user = 1000
+      fs_group    = 1000
+    }
+
+    container {
+      name    = "dev"
+      image   = data.coder_parameter.image.value
+      command = ["sh", "-c", coder_agent.main.init_script]
+
+      env {
+        name  = "CODER_AGENT_TOKEN"
+        value = coder_agent.main.token
+      }
+
+      resources {
+        requests = {
+          cpu    = "${data.coder_parameter.cpu.value}"
+          memory = "${data.coder_parameter.memory.value}Gi"
+        }
+        limits = {
+          cpu    = "${data.coder_parameter.cpu.value}"
+          memory = "${data.coder_parameter.memory.value}Gi"
+        }
+      }
+
+      volume_mount {
+        mount_path = "/home/coder"
+        name       = "home"
+      }
+    }
+
+    volume {
+      name = "home"
+      persistent_volume_claim {
+        claim_name = kubernetes_persistent_volume_claim.home.metadata[0].name
+      }
+    }
+  }
+}

--- a/terraform/coder/authentik-vault/main.tf
+++ b/terraform/coder/authentik-vault/main.tf
@@ -1,0 +1,113 @@
+terraform {
+  required_version = ">=1.14"
+  backend "kubernetes" {
+    secret_suffix = "state-coder"
+    namespace     = "terraform"
+    config_path   = "~/.kube/config"
+  }
+
+  required_providers {
+    authentik = {
+      source  = "goauthentik/authentik"
+      version = "2026.5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.8.1"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "5.9.0"
+    }
+  }
+}
+
+provider "authentik" {
+  url   = "https://auth.etsmtl.club"
+  token = var.AUTHENTIK_API_TOKEN
+}
+
+provider "vault" {
+  address          = "https://vault.etsmtl.club"
+  skip_child_token = true
+}
+
+locals {
+  app_slug     = "coder"
+  app_name     = "Coder"
+  namespace    = "coder"
+  hostname     = "coder.etsmtl.club"
+  vault_secret = "kv/data/${local.namespace}/default/coder-oidc-secret"
+}
+
+resource "random_password" "coder_client_secret" {
+  length           = 48
+  special          = true
+  override_special = "!-_="
+}
+
+resource "vault_kv_secret" "coder_oidc_secret" {
+  path = local.vault_secret
+
+  data_json = jsonencode({
+    OIDC_CLIENT_ID     = authentik_provider_oauth2.coder.client_id
+    OIDC_CLIENT_SECRET = authentik_provider_oauth2.coder.client_secret
+  })
+}
+
+data "authentik_flow" "default_authorization_flow" {
+  slug = "default-provider-authorization-explicit-consent"
+}
+
+data "authentik_flow" "default_invalidation_flow" {
+  slug = "default-provider-invalidation-flow"
+}
+
+data "authentik_property_mapping_provider_scope" "openid" {
+  managed = "goauthentik.io/providers/oauth2/scope-openid"
+}
+
+data "authentik_property_mapping_provider_scope" "email" {
+  managed = "goauthentik.io/providers/oauth2/scope-email"
+}
+
+data "authentik_property_mapping_provider_scope" "profile" {
+  managed = "goauthentik.io/providers/oauth2/scope-profile"
+}
+
+# Aucun des modules existants (outline, nodered) n'expose le claim `groups` --
+# Coder en a besoin pour le group sync OIDC (CODER_OIDC_GROUP_FIELD=groups).
+resource "authentik_property_mapping_provider_scope" "groups" {
+  name       = "coder-scope-groups"
+  scope_name = "groups"
+  expression = "return {\"groups\": [group.name for group in user.ak_groups.all()]}"
+}
+
+resource "authentik_provider_oauth2" "coder" {
+  name               = local.app_slug
+  client_id          = local.app_slug
+  client_secret      = random_password.coder_client_secret.result
+  grant_types        = ["authorization_code", "refresh_token"]
+  authorization_flow = data.authentik_flow.default_authorization_flow.id
+  invalidation_flow  = data.authentik_flow.default_invalidation_flow.id
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+    authentik_property_mapping_provider_scope.groups.id,
+  ]
+
+  allowed_redirect_uris = [
+    {
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://${local.hostname}/api/v2/users/oidc/callback"
+    },
+  ]
+}
+
+resource "authentik_application" "coder" {
+  name              = local.app_name
+  slug              = local.app_slug
+  protocol_provider = authentik_provider_oauth2.coder.id
+}

--- a/terraform/coder/authentik-vault/variables.tf
+++ b/terraform/coder/authentik-vault/variables.tf
@@ -1,0 +1,4 @@
+variable "AUTHENTIK_API_TOKEN" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
## Résumé
Bootstrap du déploiement de [Coder](https://github.com/coder/coder) sur `k8s-shared`, sur le modèle existant (planka/outline/nodered) :

- `terraform/coder/authentik-vault/` : provider OIDC Authentik (`authentik_provider_oauth2` + `authentik_application`), custom scope mapping pour exposer le claim `groups`, secret Vault `coder-oidc-secret`. Ajout de `coder` aux options de `.github/workflows/apply-tf.yml`.
- `apps/coder/resources/postgres.yaml` : cluster CNPG sur `ceph-rbd` (pas `cephfs` — voir historique de corruption CephFS sur ce cluster) + backup barman-cloud vers B2.
- `apps/coder/resources/vault.yaml` : `VaultStaticSecret` pour synchroniser le secret OIDC + `b2-creds`.
- `apps/coder/resources/certificate.yaml` + `httpproxy.yaml` : cert wildcard `coder.etsmtl.club` / `*.coder.etsmtl.club` (DNS-01 Cloudflare déjà supporté par `letsencrypt-etsmtl`) + deux `HTTPProxy` (host principal + wildcard pour l'accès direct aux apps de workspace).
- `apps/coder/coder.argoapp.yaml` + `helm/values.yaml` : déploiement multi-source ArgoCD du chart officiel `coder/coder` 2.35.3, OIDC configuré via `CODER_OIDC_*`, group sync OSS (`CODER_OIDC_GROUP_FIELD=groups`, `CODER_OIDC_GROUP_AUTO_CREATE=true`).
- `apps/coder/resources/workspaces-namespace.yaml` : namespace `coder-workspaces` dédié (isolé du control plane coderd) avec `ResourceQuota`/`LimitRange`, RBAC scopée via `coder.serviceAccount.workspaceNamespaces`.
- `apps/coder/templates/kubernetes/main.tf` : template Coder (Terraform, provider `kubernetes`) provisionnant un pod de workspace avec PVC `ceph-rbd` persistant pour le home dir et `code-server` comme app par défaut. À pousser séparément via `coder templates push kubernetes -d apps/coder/templates/kubernetes` (pas géré par ArgoCD).
- `apps/coder/coder.md` : doc de référence (état auth, rotation du secret OIDC, workspaces).

## RBAC / licence
Le **role sync** automatique (groupe Authentik → rôle Coder `Owner`/`Auditor`/`Template Admin` via claim OIDC) est une fonctionnalité **Premium/Enterprise**, indisponible en Community. Décision : rester en OSS, group sync seulement — les rôles admin (`Owner`) sont assignés manuellement après le premier login. Voir #321.

Closes #318, #319, #320, #321, #322, #323.

## Test plan
- [ ] `tofu init && tofu plan` sur `terraform/coder/authentik-vault` (via le workflow `apply-tf.yml`, module `coder`)
- [ ] Vérifier la création du `Cluster` CNPG et du secret `coder-pg-app`
- [ ] Vérifier la synchronisation du secret `coder-oidc-secret` par le Vault Secrets Operator
- [ ] Vérifier l'émission du certificat wildcard `coder-tls` par cert-manager (DNS-01 Cloudflare)
- [ ] Login OIDC via Authentik sur `https://coder.etsmtl.club`
- [ ] Vérifier que les groupes Authentik apparaissent comme groupes Coder après login
- [ ] `coder templates push kubernetes -d apps/coder/templates/kubernetes`, créer un workspace de test, vérifier le pod dans `coder-workspaces` et l'accès à code-server via le sous-domaine wildcard