### PR TITLE
chore: make pre-commit hooks installable without Nix (tofu fallback documented)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,34 @@
+# Miroir local des checks CI (clubcedille/cedille-workflows) :
+# terraform-lint, yaml-lint, kubeconform, pluto, kube-score.
+#
+# Installation :
+#   pip install pre-commit
+#   pre-commit install
+#
+# Requiert en plus, dans le PATH : kubectl, kubeconform, pluto, kube-score
+# (voir scripts/kube-validate.sh). tflint et terraform sont gérés par les
+# hooks ci-dessous.
+
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.99.4
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_tflint
+        args:
+          - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.37.1
+    hooks:
+      - id: yamllint
+        args: ["-c", ".yamllint.yml"]
+
+  - repo: local
+    hooks:
+      - id: kube-validate
+        name: kubeconform / pluto / kube-score (kustomize build)
+        entry: scripts/kube-validate.sh
+        language: script
+        pass_filenames: true
+        files: ^(apps|bases|system|common)/.*\.ya?ml$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,26 @@
 # Miroir local des checks CI (clubcedille/cedille-workflows) :
 # terraform-lint, yaml-lint, kubeconform, pluto, kube-score.
 #
-# Installation :
-#   pip install pre-commit
-#   pre-commit install
+# 1) pre-commit lui-même :
+#      Arch/Manjaro : sudo pacman -S pre-commit
+#      Ubuntu/Debian: sudo apt install pipx && pipx install pre-commit
+#      n'importe où : pipx install pre-commit   (ou: pip install --user pre-commit)
 #
-# Requiert en plus, dans le PATH : kubectl, kubeconform, pluto, kube-score
-# (voir scripts/kube-validate.sh). tflint et terraform sont gérés par les
-# hooks ci-dessous.
+# 2) kubectl + terraform/opentofu (paquets standards de ta distro) :
+#      Arch/Manjaro : sudo pacman -S kubectl opentofu
+#      Ubuntu/Debian: sudo apt install kubectl   # opentofu: voir
+#                     https://opentofu.org/docs/intro/install/#linux-package-manager
+#      Fedora/RHEL  : sudo dnf install kubectl terraform
+#    Les hooks Terraform ci-dessous détectent automatiquement `tofu` si
+#    `terraform` est absent du PATH -- avoir uniquement OpenTofu installé
+#    fonctionne sans configuration supplémentaire.
+#
+# 3) tflint, kubeconform, pluto, kube-score (pas de paquet standard partout) :
+#      ./scripts/install-hook-deps.sh
+#    Installe les mêmes versions que la CI dans ~/.local/bin (pas de sudo).
+#
+# 4) Activer les hooks :
+#      pre-commit install
 
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,6 @@
+# Vendored from ClubCedille/cedille-workflows (.tflint.hcl) so pre-commit runs
+# the exact same ruleset as the terraform-lint CI job.
+plugin "terraform" {
+  enabled = true
+  preset  = "recommended"
+}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,36 @@
+# Vendored from ClubCedille/cedille-workflows (.yamllint.yml) so pre-commit
+# runs the exact same rules as the yaml-lint-check CI job.
+# https://github.com/ContainerSolutions/kubernetes-examples/blob/master/.yamllint
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+ignore: |
+  .github/
+
+rules:
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start: disable
+  empty-lines: enable
+  empty-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: disable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/apps/coder/resources/kustomization.yaml
+++ b/apps/coder/resources/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Pas de `namespace:` global ici : workspaces-namespace.yaml déclare
+# explicitement `coder-workspaces` pour ses ressources (Namespace,
+# ResourceQuota, LimitRange), et les forcer vers `coder` casserait ça.
+# Les autres manifests héritent du namespace `coder` via
+# ArgoCD (destination.namespace dans coder.argoapp.yaml).
+
+resources:
+  - certificate.yaml
+  - httpproxy.yaml
+  - postgres.yaml
+  - vault.yaml
+  - workspaces-namespace.yaml

--- a/scripts/install-hook-deps.sh
+++ b/scripts/install-hook-deps.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Installe, sans sudo, les binaires requis par .pre-commit-config.yaml qui ne
+# sont pas des paquets standards des distros (Arch/Ubuntu/Fedora/...) :
+# tflint, kubeconform, pluto, kube-score. Mêmes versions que la CI
+# (clubcedille/cedille-workflows), installés dans ~/.local/bin.
+#
+# kubectl, pre-commit et terraform/opentofu NE sont PAS installés ici -- ce
+# sont des paquets standards, à installer via le gestionnaire de paquets de
+# ta distro (ou pip/pipx pour pre-commit) :
+#
+#   Arch / Manjaro   : sudo pacman -S kubectl opentofu pre-commit
+#   Ubuntu / Debian   : sudo apt install kubectl pre-commit   # terraform/opentofu :
+#                       voir https://opentofu.org/docs/intro/install/#linux-package-manager
+#   Fedora / RHEL     : sudo dnf install kubectl pre-commit terraform
+#   n'importe où      : pipx install pre-commit
+#
+# Note : les hooks Terraform (antonbabenko/pre-commit-terraform) détectent
+# automatiquement OpenTofu si `terraform` n'est pas sur le PATH -- avoir
+# uniquement `tofu` installé fonctionne sans configuration supplémentaire.
+
+set -euo pipefail
+
+TFLINT_VERSION="0.53.0"
+KUBECONFORM_VERSION="0.8.0"
+PLUTO_VERSION="5.24.0"
+KUBE_SCORE_VERSION="1.20.0"
+
+bin_dir="${HOOK_DEPS_BIN_DIR:-$HOME/.local/bin}"
+mkdir -p "$bin_dir"
+
+os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+arch="$(uname -m)"
+case "$arch" in
+  x86_64 | amd64) arch="amd64" ;;
+  aarch64 | arm64) arch="arm64" ;;
+  *)
+    echo "Architecture non supportée par ce script : $arch" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$os" != "linux" ] && [ "$os" != "darwin" ]; then
+  echo "OS non supporté par ce script : $os" >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "==> tflint v${TFLINT_VERSION}"
+curl -fsSL "https://github.com/terraform-linters/tflint/releases/download/v${TFLINT_VERSION}/tflint_${os}_${arch}.zip" -o "$tmp/tflint.zip"
+unzip -oq "$tmp/tflint.zip" -d "$bin_dir"
+chmod +x "$bin_dir/tflint"
+
+echo "==> kubeconform v${KUBECONFORM_VERSION}"
+curl -fsSL "https://github.com/yannh/kubeconform/releases/download/v${KUBECONFORM_VERSION}/kubeconform-${os}-${arch}.tar.gz" |
+  tar xz -C "$bin_dir" kubeconform
+
+echo "==> pluto v${PLUTO_VERSION}"
+curl -fsSL "https://github.com/FairwindsOps/pluto/releases/download/v${PLUTO_VERSION}/pluto_${PLUTO_VERSION}_${os}_${arch}.tar.gz" |
+  tar xz -C "$bin_dir" pluto
+
+echo "==> kube-score v${KUBE_SCORE_VERSION}"
+curl -fsSL "https://github.com/zegl/kube-score/releases/download/v${KUBE_SCORE_VERSION}/kube-score_${KUBE_SCORE_VERSION}_${os}_${arch}" \
+  -o "$bin_dir/kube-score"
+chmod +x "$bin_dir/kube-score"
+
+echo
+echo "Installé dans $bin_dir :"
+ls -1 "$bin_dir" | grep -E '^(tflint|kubeconform|pluto|kube-score)$'
+echo
+case ":$PATH:" in
+  *":$bin_dir:"*) ;;
+  *) echo "⚠️  $bin_dir n'est pas dans ton PATH -- ajoute-le dans ton shell rc." ;;
+esac

--- a/scripts/kube-validate.sh
+++ b/scripts/kube-validate.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Local mirror of the kubeconform / pluto / kube-score CI checks
+# (clubcedille/cedille-workflows), run by pre-commit on staged files.
+#
+# Builds each changed kustomization root with `kubectl kustomize --enable-helm`
+# and validates the rendered manifests. kubeconform and pluto are blocking;
+# kube-score is report-only (the CI-side CRITICAL gate depends on `/kube-score
+# skip` PR comments, which don't exist locally).
+#
+# Requires: kubectl, kubeconform, pluto, kube-score.
+
+set -euo pipefail
+
+changed_root_for() {
+  local path="$1"
+  IFS=/ read -r top second third fourth _ <<<"$path"
+  case "$path" in
+    apps/clubs/*/*/*)
+      printf '%s/%s/%s/%s\n' "$top" "$second" "$third" "$fourth"
+      ;;
+    apps/*/* | bases/*/* | system/*/* | common/*/*)
+      printf '%s/%s\n' "$top" "$second"
+      ;;
+  esac
+}
+
+roots_to_build=$(
+  { printf '%s\n' "$@" | grep -E '^(apps|bases|system|common)/' || true; } |
+    while IFS= read -r f; do changed_root_for "$f"; done |
+    sed 's:/$::' | sort -u
+)
+
+if [ -z "${roots_to_build:-}" ]; then
+  echo "kube-validate: rien à valider (aucun fichier sous apps/bases/system/common)."
+  exit 0
+fi
+
+out_dir="$(mktemp -d)"
+trap 'rm -rf "$out_dir"' EXIT
+
+roots=()
+for d in apps bases system common; do
+  [ -d "$d" ] && roots+=("./$d")
+done
+
+built_any=false
+if [ "${#roots[@]}" -gt 0 ]; then
+  while IFS= read -r -d '' kustom; do
+    dir="$(dirname "$kustom")"
+    rel="${dir#./}"
+    should_build=false
+    while IFS= read -r root_key; do
+      [ -z "$root_key" ] && continue
+      if [[ "$rel" == "$root_key" || "$rel" == "$root_key"/* ]]; then
+        should_build=true
+        break
+      fi
+    done <<<"$roots_to_build"
+
+    if [ "$should_build" = true ]; then
+      name="${rel//\//_}.yaml"
+      echo "▶ building $rel"
+      if kubectl kustomize --enable-helm --load-restrictor LoadRestrictionsNone "$dir" >"$out_dir/$name"; then
+        built_any=true
+      else
+        echo "::error::❌ kustomize build failed: $rel"
+        rm -f "$out_dir/$name"
+      fi
+    fi
+  done < <(find "${roots[@]}" -type f \( -name kustomization.yaml -o -name kustomization.yml \) -not -path '*/base/*' -print0)
+fi
+
+if [ "$built_any" = false ]; then
+  echo "kube-validate: aucune kustomization buildable trouvée."
+  exit 0
+fi
+
+shopt -s nullglob
+files=("$out_dir"/*.yaml)
+
+echo "--- kubeconform ---"
+kubeconform \
+  -summary -output text \
+  -kubernetes-version 1.30.0 \
+  -schema-location default \
+  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+  -ignore-missing-schemas \
+  "${files[@]}"
+
+echo "--- pluto (deprecated APIs) ---"
+pluto detect-files -d "$out_dir" --target-versions k8s=v1.31.0 -o wide
+
+echo "--- kube-score (rapport, non bloquant localement) ---"
+kube-score score --output-format ci "${files[@]}" || true


### PR DESCRIPTION
## Contexte
Suite à #324 : les hooks pre-commit ajoutés fonctionnaient mais avaient été testés/validés via Nix. Cette PR les rend utilisables sans Nix, sur Arch/Ubuntu/Fedora comme n'importe où ailleurs. Ajoute aussi le `kustomization.yaml` manquant sous `apps/coder/resources` pour que le hook (et la CI) valident réellement quelque chose.

## Changements
- `.pre-commit-config.yaml` : instructions d'installation par distro (pacman/apt/dnf) pour `pre-commit`, `kubectl`, `terraform`/`opentofu`, au lieu de supposer Nix.
- `scripts/install-hook-deps.sh` : installe `tflint`/`kubeconform`/`pluto`/`kube-score` (pas de paquet standard partout) depuis les mêmes releases GitHub pinnées que la CI, dans `~/.local/bin`, sans sudo.
- Fallback OpenTofu : **déjà supporté nativement** par `antonbabenko/pre-commit-terraform` (détection automatique de `tofu` si `terraform` est absent du PATH) — vérifié en local avec uniquement `tofu` installé, aucune config additionnelle requise. Documenté dans les commentaires du fichier.
- `apps/coder/resources/kustomization.yaml` : sans lui, `apps/coder/resources` (ajouté par #324) était silencieusement ignoré par kubeconform/pluto/kube-score, en CI comme dans le hook local -- même gap que `apps/planka/resources`. Vérifié : kubeconform 12/12 valide, pluto clean, kube-score n'a rien à signaler (dossier composé uniquement de CRDs/Namespace/Quota, pas de pod spec). Pas de `namespace:` global dans la kustomization : `workspaces-namespace.yaml` déclare explicitement `coder-workspaces` pour ses propres ressources, qu'un `namespace: coder` global aurait silencieusement écrasées.

## Test plan
- [x] `install-hook-deps.sh` testé : télécharge et installe les 4 binaires (versions confirmées identiques à la CI : tflint 0.53.0, kubeconform 0.8.0, pluto 5.24.0, kube-score 1.20.0)
- [x] `pre-commit run` testé de bout en bout avec seulement `tofu` (pas `terraform`) + les binaires du script d'install sur le PATH (pas de Nix) : les 4 hooks passent
- [x] `kustomization.yaml` : build + kubeconform/pluto/kube-score vérifiés réellement
- [ ] Confirmer sur une vraie machine Arch/Ubuntu (pas juste NixOS)