### PR TITLE
fix(coder): add kustomization.yaml so kubeconform/pluto/kube-score actually run

### DIFF
--- a/apps/coder/resources/kustomization.yaml
+++ b/apps/coder/resources/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Pas de `namespace:` global ici : workspaces-namespace.yaml déclare
+# explicitement `coder-workspaces` pour ses ressources (Namespace,
+# ResourceQuota, LimitRange), et les forcer vers `coder` casserait ça.
+# Les autres manifests héritent du namespace `coder` via
+# ArgoCD (destination.namespace dans coder.argoapp.yaml).
+
+resources:
+  - certificate.yaml
+  - httpproxy.yaml
+  - postgres.yaml
+  - vault.yaml
+  - workspaces-namespace.yaml


### PR DESCRIPTION
## Contexte
`apps/coder/resources` (ajouté par #324) n'a pas de `kustomization.yaml`, comme `apps/planka/resources`. La logique de découverte des kustomizations CI (`kubernetes-repo-standards` : kubeconform, pluto, kube-score) — et le hook pre-commit `kube-validate.sh` de #326 — ne construisent que les répertoires qui *ont* un `kustomization.yaml`. Sans lui, ces manifests étaient validés par... rien. Le check CI passait, mais vide.

## Changement
Ajoute `apps/coder/resources/kustomization.yaml` listant les 5 manifests existants. Pas de `namespace:` global : `workspaces-namespace.yaml` déclare explicitement `coder-workspaces` pour ses propres ressources (Namespace/ResourceQuota/LimitRange) et un `namespace: coder` global aurait silencieusement écrasé ça.

## Vérifié localement
- `kubectl kustomize --enable-helm apps/coder/resources` : build propre, `coder-workspaces` intact sur les bonnes ressources
- `kubeconform` : 12/12 valid
- `pluto` : aucune API dépréciée
- `kube-score` : rien à signaler (ce dossier ne contient que des CRDs/Namespace/Quota, pas de pod spec -- celle-ci vient du chart Helm en amont, pas d'ici)
- Testé avec le script `kube-validate.sh` de #326 : détecte et build correctement ce dossier une fois les deux mergés

🤖 Generated with [Claude Code](https://claude.com/claude-code)