### PR TITLE
fix(coder): drop explicit image tag causing ImagePullBackOff

### DIFF
--- a/apps/coder/helm/values.yaml
+++ b/apps/coder/helm/values.yaml
@@ -1,6 +1,8 @@
 coder:
-  image:
-    tag: "2.35.3"
+  # Pas de coder.image.tag ici : le chart calcule le défaut en préfixant
+  # .Chart.AppVersion par "v" (ex: v2.35.3, le tag réel publié sur ghcr.io).
+  # Un tag explicite ici écraserait ce préfixe -- "2.35.3" (sans le "v")
+  # n'existe pas comme image, seul "v2.35.3" existe.
 
   replicaCount: 1
 


### PR DESCRIPTION
## Contexte
En vérifiant le déploiement réel (post #324 + tofu apply du module coder), le pod `coder` est en `ImagePullBackOff` depuis le déploiement :

```
Failed to pull image "ghcr.io/coder/coder:2.35.3": ... not found
```

## Cause
`coder.image.tag: "2.35.3"` dans `apps/coder/helm/values.yaml` écrase le calcul par défaut du chart (`printf "v%v" .Chart.AppVersion` → `v2.35.3`). Le tag réellement publié sur `ghcr.io/coder/coder` a le préfixe `v` (`v2.35.3`) ; `2.35.3` seul n'existe pas.

## Changement
Retire l'override -- le chart calcule déjà le bon tag à partir de sa propre version (pinnée à `2.35.3` via `targetRevision` dans `coder.argoapp.yaml`).

## Vérifié
- `helm template` résout maintenant `image: ghcr.io/coder/coder:v2.35.3`
- Tag confirmé présent sur `ghcr.io/coder/coder` (requête anonyme à l'API du registry)