### PR TITLE
fix(coder): compose CODER_PG_CONNECTION_URL from CNPG's own secret

### DIFF
--- a/apps/coder/coder.md
+++ b/apps/coder/coder.md
@@ -40,9 +40,30 @@ régénère le secret côté Authentik et le réécrit dans Vault. Le
 ## Base de données
 
 CNPG (`apps/coder/resources/postgres.yaml`), storageClass `ceph-rbd` (pas
-`cephfs`), secret applicatif auto-généré `coder-pg-app` (clé `uri` utilisée
-directement comme `CODER_PG_CONNECTION_URL`). Backup quotidien vers B2 via
-barman-cloud.
+`cephfs`). Backup quotidien vers B2 via barman-cloud.
+
+**Le secret `coder-pg-app` doit être créé manuellement avant le premier
+bootstrap du Cluster** -- vérifié empiriquement : `bootstrap.initdb.secret.name`
+ne génère *pas* automatiquement le secret s'il n'existe pas déjà (le rôle
+`coder` reste alors sans mot de passe, `rolpassword` null). Volontairement
+**pas** commité dans git (contrairement à `postgresql-forgejo-app`/
+`nextcloud-postgresql` ailleurs dans ce repo) :
+
+```sh
+kubectl create secret generic coder-pg-app \
+  --type=kubernetes.io/basic-auth \
+  --from-literal=username=coder \
+  --from-literal=password="$(openssl rand -base64 32)" \
+  -n coder
+```
+
+`CODER_PG_CONNECTION_URL` est composé dans `apps/coder/helm/values.yaml` via
+l'expansion `$(VAR)` de Kubernetes à partir de `username`/`password` (ce
+secret ne contient jamais de clé `uri`).
+
+Si le Cluster doit être recréé (perte du mot de passe, migration...), ce
+secret doit exister *avant* de réappliquer `postgres.yaml`, sinon répéter
+l'étape ci-dessus avec un nouveau mot de passe.
 
 ## Workspaces
 

--- a/apps/coder/helm/values.yaml
+++ b/apps/coder/helm/values.yaml
@@ -65,9 +65,21 @@ coder:
     - name: CODER_OIDC_GROUP_AUTO_CREATE
       value: "true"
 
-    # Base de données (CNPG, voir apps/coder/resources/postgres.yaml)
-    - name: CODER_PG_CONNECTION_URL
+    # Base de données (CNPG, voir apps/coder/resources/postgres.yaml).
+    # Le secret `coder-pg-app` généré par CNPG ne contient que `username`/
+    # `password` (type kubernetes.io/basic-auth, jamais de clé `uri` -- voir
+    # les secrets équivalents forgejo/nextcloud/outline). On compose l'URL
+    # via l'expansion $(VAR) de Kubernetes, qui référence les env vars
+    # précédentes du même conteneur.
+    - name: CODER_PG_USER
       valueFrom:
         secretKeyRef:
           name: coder-pg-app
-          key: uri
+          key: username
+    - name: CODER_PG_PASSWORD
+      valueFrom:
+        secretKeyRef:
+          name: coder-pg-app
+          key: password
+    - name: CODER_PG_CONNECTION_URL
+      value: "postgresql://$(CODER_PG_USER):$(CODER_PG_PASSWORD)@postgresql-coder-rw.coder.svc.cluster.local:5432/coder"

--- a/terraform/coder/authentik-vault/main.tf
+++ b/terraform/coder/authentik-vault/main.tf
@@ -83,6 +83,13 @@ resource "authentik_property_mapping_provider_scope" "groups" {
   expression = "return {\"groups\": [group.name for group in user.ak_groups.all()]}"
 }
 
+# Authentik signe l'id_token en HS256 (symétrique) si `signing_key` n'est pas
+# défini. Coder n'accepte que RS256 -- sans ça : "Failed to verify OIDC
+# token: unexpected signature algorithm HS256".
+data "authentik_certificate_key_pair" "default" {
+  name = "authentik Self-signed Certificate"
+}
+
 resource "authentik_provider_oauth2" "coder" {
   name               = local.app_slug
   client_id          = local.app_slug
@@ -90,6 +97,7 @@ resource "authentik_provider_oauth2" "coder" {
   grant_types        = ["authorization_code", "refresh_token"]
   authorization_flow = data.authentik_flow.default_authorization_flow.id
   invalidation_flow  = data.authentik_flow.default_invalidation_flow.id
+  signing_key        = data.authentik_certificate_key_pair.default.id
   property_mappings = [
     data.authentik_property_mapping_provider_scope.openid.id,
     data.authentik_property_mapping_provider_scope.email.id,


### PR DESCRIPTION
## Contexte
Le pod `coder` était bloqué (`CreateContainerConfigError: secret "coder-pg-app" not found`) suite à une erreur transitoire de l'opérateur CNPG pendant le bootstrap initial (plugin barman-cloud, "closed pool") qui a empêché la création du secret applicatif. Ce point s'est résolu tout seul depuis (aucune récurrence dans les logs de l'opérateur).

En creusant, deuxième problème indépendant : notre `CODER_PG_CONNECTION_URL` référençait une clé `uri` sur `coder-pg-app`, mais le secret auto-généré par CNPG (`bootstrap.initdb.secret`) ne contient jamais que `username`/`password` (type `kubernetes.io/basic-auth`) -- vérifié sur les secrets équivalents forgejo/nextcloud/outline. Cette clé n'aurait donc jamais existé, même une fois le secret créé.

## Changement
Compose `CODER_PG_CONNECTION_URL` via l'expansion `$(VAR)` native de Kubernetes (env vars dépendantes dans le même conteneur) à partir de `username`/`password`, plutôt que d'introduire des credentials DB gérés par Terraform/Vault -- pas besoin de toucher la policy Vault de `k8s-base` pour ça.

## Test plan
- [ ] Supprimer le Cluster CNPG `postgresql-coder` + ses PVC (aucune donnée réelle, coderd n'a jamais démarré) pour forcer un nouveau bootstrap propre
- [ ] Vérifier la création du secret `coder-pg-app` (username/password) par CNPG
- [ ] Vérifier que le pod `coder` démarre (plus de `CreateContainerConfigError`)