### PR TITLE
fix(coder): ignore email_verified claim from Authentik

### DIFF
--- a/apps/coder/helm/values.yaml
+++ b/apps/coder/helm/values.yaml
@@ -54,6 +54,12 @@ coder:
       value: "Se connecter avec Authentik"
     - name: CODER_OIDC_ALLOW_SIGNUPS
       value: "true"
+    # Authentik ne marque `email_verified: true` que si la vérification par
+    # courriel est explicitement configurée dans le flow -- ce qui n'est pas
+    # le cas ici. SSO interne de confiance : on ignore ce claim plutôt que
+    # d'exiger une vérification qu'Authentik ne fait pas.
+    - name: CODER_OIDC_IGNORE_EMAIL_VERIFIED
+      value: "true"
 
     # Group sync (OSS) : les groupes Authentik (claim `groups`, voir le scope
     # mapping custom dans terraform/coder/authentik-vault) sont répliqués en


### PR DESCRIPTION
## Contexte
Login OIDC échoue avec "Email not verified" après le fix du signing_key (RS256). Authentik ne définit `email_verified: true` que si la vérification par courriel est explicitement activée dans le flow d'inscription/authentification -- ce qui n'est pas configuré ici (SSO interne, comptes déjà provisionnés/de confiance).

## Changement
`CODER_OIDC_IGNORE_EMAIL_VERIFIED=true` -- confirmé via `coder server --help` dans le pod en cours d'exécution (`--oidc-ignore-email-verified`).

## Test plan
- [ ] Retenter le login OIDC après déploiement