### PR TITLE
feat(authentik): shared email_verified scope mapping for all apps

### DIFF
--- a/terraform/authentik/main.tf
+++ b/terraform/authentik/main.tf
@@ -27,3 +27,17 @@ resource "authentik_brand" "authentik-test" {
   # web_certificate = "" # (String)
 
 }
+
+# Authentik ne pose `email_verified: true` que si la vérification par
+# courriel est explicitement configurée dans le flow d'un provider -- ce qui
+# n'est le cas pour aucune de nos apps. Plusieurs clients OIDC (Coder,
+# potentiellement d'autres à l'avenir) rejettent ou avertissent si ce claim
+# est absent/false. Ce scope mapping partagé remplace le mapping "email"
+# managé par défaut : à référencer par nom (data source) dans les modules
+# terraform/*/authentik-vault plutôt que de contourner le problème côté
+# client (ex: CODER_OIDC_IGNORE_EMAIL_VERIFIED).
+resource "authentik_property_mapping_provider_scope" "email_verified" {
+  name       = "cedille-scope-email-verified"
+  scope_name = "email"
+  expression = "return {\"email\": user.email, \"email_verified\": True}"
+}

--- a/terraform/coder/authentik-vault/main.tf
+++ b/terraform/coder/authentik-vault/main.tf
@@ -67,8 +67,12 @@ data "authentik_property_mapping_provider_scope" "openid" {
   managed = "goauthentik.io/providers/oauth2/scope-openid"
 }
 
+# Le mapping "email" managé par défaut d'Authentik ne pose pas
+# email_verified: true (aucune vérification par courriel configurée dans nos
+# flows) -- on utilise le mapping partagé de terraform/authentik/main.tf à la
+# place, applicable à toute future app avec le même besoin.
 data "authentik_property_mapping_provider_scope" "email" {
-  managed = "goauthentik.io/providers/oauth2/scope-email"
+  name = "cedille-scope-email-verified"
 }
 
 data "authentik_property_mapping_provider_scope" "profile" {


### PR DESCRIPTION
## Contexte
Suite à #330 (`CODER_OIDC_IGNORE_EMAIL_VERIFIED`) : Authentik ne pose jamais `email_verified: true` sur aucun de nos flows (aucune vérification par courriel configurée) -- c'est systémique, pas spécifique à Coder. D'autres apps OIDC pourraient avoir la même exigence à l'avenir.

## Changement
- `terraform/authentik/main.tf` (module global) : nouveau scope mapping partagé `cedille-scope-email-verified`, qui remplace le mapping "email" managé par défaut et pose `email_verified: true` explicitement.
- `terraform/coder/authentik-vault/main.tf` : utilise ce mapping partagé au lieu du mapping managé par défaut pour le provider Coder.

Les futures apps OIDC peuvent référencer ce même mapping par nom (data source), au lieu de contourner le problème côté client à chaque fois.

`CODER_OIDC_IGNORE_EMAIL_VERIFIED` (#330) reste en place comme filet de sécurité -- pas besoin de le retirer.

## Notes de déploiement
- `terraform/authentik/` est le module racine, appliqué via **Terraform Cloud** (pas `apply-tf.yml`) -- vérifier après merge si un apply manuel est requis dans l'UI TFC selon la config du workspace.
- Une fois le mapping créé, relancer `apply-tf.yml` (module `coder`) pour que le provider Coder l'utilise.

## Test plan
- [ ] Vérifier l'apply Terraform Cloud du module `authentik`
- [ ] Relancer `apply-tf.yml` module `coder`
- [ ] Confirmer le claim `email_verified: true` dans le token (ou simplement que le login OIDC passe, avec ou sans le flag `ignore` côté Coder)