### PR TITLE
feat(coder): add coder-poc workspace namespace

### DIFF
--- a/apps/coder/helm/values.yaml
+++ b/apps/coder/helm/values.yaml
@@ -28,10 +28,11 @@ coder:
       - name: coder-workspaces
         workspacePerms: true
         enableDeployments: false
-      # Namespace de test/PoC, séparé de coder-workspaces.
+      # Namespace de test/PoC, séparé de coder-workspaces. enableDeployments
+      # requis : le template testé ici crée un Deployment, pas juste un Pod.
       - name: coder-poc
         workspacePerms: true
-        enableDeployments: false
+        enableDeployments: true
 
   env:
     - name: CODER_ACCESS_URL

--- a/apps/coder/helm/values.yaml
+++ b/apps/coder/helm/values.yaml
@@ -28,6 +28,10 @@ coder:
       - name: coder-workspaces
         workspacePerms: true
         enableDeployments: false
+      # Namespace de test/PoC, séparé de coder-workspaces.
+      - name: coder-poc
+        workspacePerms: true
+        enableDeployments: false
 
   env:
     - name: CODER_ACCESS_URL

--- a/apps/coder/resources/coder-poc-namespace.yaml
+++ b/apps/coder/resources/coder-poc-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: coder-poc


### PR DESCRIPTION
## Contexte
Test en cours d'un workspace/template pointant vers un namespace `coder-poc` distinct de `coder-workspaces`. Le ServiceAccount `coder` n'y avait pas les permissions (`persistentvolumeclaims is forbidden`).

## Changement
- `apps/coder/resources/coder-poc-namespace.yaml` : namespace (déjà créé manuellement pour débloquer le test, rendu ici git-tracké).
- `apps/coder/helm/values.yaml` : ajoute `coder-poc` à `coder.serviceAccount.workspaceNamespaces`, même pattern que `coder-workspaces`.

RBAC (Role/RoleBinding) déjà appliquée manuellement pour débloquer le test en cours ; cette PR aligne git pour éviter un drift/prune ArgoCD.