### PR TITLE
fix(coder): extend OIDC session duration and harden workspaces namespace PSA

### DIFF
--- a/apps/coder/resources/workspaces-namespace.yaml
+++ b/apps/coder/resources/workspaces-namespace.yaml
@@ -2,6 +2,20 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: coder-workspaces
+  # Sans ces labels, le namespace hérite du niveau PSA "privileged" par
+  # défaut de Kubernetes -- rien n'empêche alors un futur template Coder de
+  # tourner en privileged:true, hostPath ou hostNetwork. Coder exécute du
+  # code utilisateur non fiable dans ce namespace, donc on enforce
+  # "baseline" (le template actuel -- apps/coder/templates/kubernetes/main.tf --
+  # tourne déjà en run_as_user non-root sans capacités additionnelles, donc
+  # compatible).
+  labels:
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: latest
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: latest
 ---
 apiVersion: v1
 kind: ResourceQuota

--- a/terraform/coder/authentik-vault/main.tf
+++ b/terraform/coder/authentik-vault/main.tf
@@ -102,6 +102,11 @@ resource "authentik_provider_oauth2" "coder" {
   authorization_flow = data.authentik_flow.default_authorization_flow.id
   invalidation_flow  = data.authentik_flow.default_invalidation_flow.id
   signing_key        = data.authentik_certificate_key_pair.default.id
+
+  # Défaut Authentik = access_token_validity "minutes=5" -- trop court pour
+  # une session de dev Coder (déconnexions en pleine journée de travail).
+  access_token_validity  = "hours=12"
+  refresh_token_validity = "days=30"
   property_mappings = [
     data.authentik_property_mapping_provider_scope.openid.id,
     data.authentik_property_mapping_provider_scope.email.id,


### PR DESCRIPTION
## Résumé
- Les sessions Coder duraient ~5 min car `authentik_provider_oauth2.coder` n'overridait pas `access_token_validity` (défaut Authentik = `minutes=5`). Passé à `hours=12`, avec `refresh_token_validity = days=30` explicite. Le changement a déjà été appliqué manuellement dans Authentik pour effet immédiat ; cette PR aligne le Terraform pour éviter un drift au prochain apply.
- `coder-workspaces` n'avait aucun label Pod Security Admission, donc héritait du niveau `privileged` par défaut. Coder y exécute du code utilisateur non fiable (templates de workspace) : sans ce label, rien n'empêche un futur template de tourner en `privileged: true` / `hostPath` / `hostNetwork`. Ajout de `pod-security.kubernetes.io/enforce: baseline` (compatible avec le template actuel, qui tourne déjà en non-root sans capacités additionnelles), avec `audit`/`warn` à `restricted` pour visibilité avant un futur durcissement.

## Test plan
- [ ] `terraform plan` sur `terraform/coder/authentik-vault` : diff attendu limité à `access_token_validity`/`refresh_token_validity` (no-op si déjà appliqué manuellement dans Authentik avec les mêmes valeurs)
- [ ] Après sync ArgoCD, vérifier `kubectl get ns coder-workspaces -o yaml` pour les labels PSA
- [ ] Démarrer un workspace Coder existant et confirmer qu'il démarre toujours normalement (le template actuel est compatible `baseline`)
- [ ] Confirmer qu'une session Coder reste active >5 min sans re-authentification