### PR TITLE
Add byzantium-etsblockchain website deployment

### DIFF
--- a/apps/clubs/byzantium/etsblockchain/base/deployment.yaml
+++ b/apps/clubs/byzantium/etsblockchain/base/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: byzantium-etsblockchain
+  annotations:
+    kube-score/ignore: pod-networkpolicy,container-image-tag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: byzantium-etsblockchain
+  template:
+    metadata:
+      labels:
+        app: byzantium-etsblockchain
+    spec:
+      securityContext:
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+      imagePullSecrets:
+        - name: ghcr-clubcedille-secret
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: etsblockchain
+          image: ghcr.io/clubcedille/etsblockchain:latest
+          imagePullPolicy: Always
+          env:
+            - name: RESEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: etsblockchain-secret
+                  key: RESEND_API_KEY
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /mission
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/clubs/byzantium/etsblockchain/base/kustomization.yaml
+++ b/apps/clubs/byzantium/etsblockchain/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/apps/clubs/byzantium/etsblockchain/base/service.yaml
+++ b/apps/clubs/byzantium/etsblockchain/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: byzantium-etsblockchain-svc
+spec:
+  selector:
+    app: byzantium-etsblockchain
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/apps/clubs/byzantium/etsblockchain/etsblockchain.argoapp.yaml
+++ b/apps/clubs/byzantium/etsblockchain/etsblockchain.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: byzantium-etsblockchain
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: etsblockchain=ghcr.io/clubcedille/etsblockchain:latest
+    argocd-image-updater.argoproj.io/etsblockchain.update-strategy: digest
+    argocd-image-updater.argoproj.io/etsblockchain.pull-secret: pullsecret:argocd/ghcr-clubcedille-secret
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: byzantium-etsblockchain
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/byzantium/etsblockchain/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/byzantium/etsblockchain/prod/ingress.yaml
+++ b/apps/clubs/byzantium/etsblockchain/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: byzantium-etsblockchain
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: byzantium-etsblockchain-tls
+      hosts:
+        - blockchain.prodv2.cedille.club
+  rules:
+    - host: blockchain.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: byzantium-etsblockchain-svc
+                port:
+                  number: 80

--- a/apps/clubs/byzantium/etsblockchain/prod/ingress.yaml
+++ b/apps/clubs/byzantium/etsblockchain/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: byzantium-etsblockchain
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-http
+    cert-manager.io/cluster-issuer: letsencrypt-etsmtl
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:
@@ -11,9 +11,9 @@ spec:
   tls:
     - secretName: byzantium-etsblockchain-tls
       hosts:
-        - blockchain.prodv2.cedille.club
+        - blockchain.etsmtl.club
   rules:
-    - host: blockchain.prodv2.cedille.club
+    - host: blockchain.etsmtl.club
       http:
         paths:
           - pathType: Prefix

--- a/apps/clubs/byzantium/etsblockchain/prod/kustomization.yaml
+++ b/apps/clubs/byzantium/etsblockchain/prod/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/
+  - ingress.yaml
+  - vault-secret.yaml

--- a/apps/clubs/byzantium/etsblockchain/prod/vault-secret.yaml
+++ b/apps/clubs/byzantium/etsblockchain/prod/vault-secret.yaml
@@ -1,0 +1,39 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: ghcr-clubcedille-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: docker
+      path: kv-system/default_passwords/docker
+  output:
+    name: ghcr-clubcedille-secret
+    stringData:
+      .dockerconfigjson: '{{ b64dec .docker.config }}'
+    type: kubernetes.io/dockerconfigjson
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: etsblockchain-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: etsblockchain
+      path: kv/data/byzantium-etsblockchain/default/config
+  output:
+    name: etsblockchain-secret
+    stringData:
+      RESEND_API_KEY: '{{ .etsblockchain.resend_api_key }}'
+    type: opaque


### PR DESCRIPTION
Deploys the ETS Blockchain website to the shared cluster in namespace `byzantium-etsblockchain`.

- URL: https://blockchain.prodv2.cedille.club
- Image: ghcr.io/clubcedille/etsblockchain:latest (auto-updated via argocd-image-updater)
- Next.js app on port 3000, RESEND_API_KEY from Vault