### PR TITLE
sonarqube: bump chart to 2026.3.1, match community-branch-plugin 26.5.0

### DIFF
--- a/apps/sonarqube/prod/kustomization.yaml
+++ b/apps/sonarqube/prod/kustomization.yaml
@@ -9,6 +9,6 @@ helmCharts:
   - name: sonarqube
     releaseName: sonarqube
     repo: https://SonarSource.github.io/helm-chart-sonarqube
-    version: 2026.2.1
+    version: 2026.3.1
     valuesFile: values.yaml
     namespace: sonarqube

--- a/apps/sonarqube/prod/values.yaml
+++ b/apps/sonarqube/prod/values.yaml
@@ -63,7 +63,7 @@ extraInitContainers:
     command:
       - sh
       - -c
-      - wget -O /tmp/sonarqube-webapp.zip https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/26.3.0/sonarqube-webapp.zip &&
+      - wget -O /tmp/sonarqube-webapp.zip https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/26.5.0/sonarqube-webapp.zip &&
         unzip -o /tmp/sonarqube-webapp.zip -d /web &&
         chmod -R 755 /web &&
         chown -R 1000:0 /web &&
@@ -81,7 +81,7 @@ tests:
   #
 plugins:
   install:
-    - https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/26.3.0/sonarqube-community-branch-plugin-26.3.0.jar
+    - https://github.com/mc1arke/sonarqube-community-branch-plugin/releases/download/26.5.0/sonarqube-community-branch-plugin-26.5.0.jar
 
   # For use behind a corporate proxy when downloading plugins
   # httpProxy: ""
@@ -105,8 +105,8 @@ sonarProperties:
   sonar.core.serverBaseURL: https://sonarqube.etsmtl.club
   sonar.lf.enableGravatar: true
   sonar.log.level: INFO
-  sonar.web.javaAdditionalOpts: "-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-26.3.0.jar=web"
-  sonar.ce.javaAdditionalOpts: "-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-26.3.0.jar=ce"
+  sonar.web.javaAdditionalOpts: "-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-26.5.0.jar=web"
+  sonar.ce.javaAdditionalOpts: "-javaagent:/opt/sonarqube/extensions/plugins/sonarqube-community-branch-plugin-26.5.0.jar=ce"
   sonar.auth.saml.enabled: true
   # applicationId == authentik Audience
   sonar.auth.saml.applicationId: sonarqube


### PR DESCRIPTION
## Résumé
- Bump du chart Helm `sonarqube` de `2026.2.1` à `2026.3.1` (au lieu de `2026.4.0`)
- Bump du `community-branch-plugin` de `26.3.0` à `26.5.0`

## Pourquoi 2026.3.1 et non 2026.4.0 ?

Le chart `2026.4.0` déploie l'image SonarQube Community `26.7.0`, mais la dernière release
du `community-branch-plugin` (26.5.0) ne cible explicitement que SonarQube 26.5 — pas de
release testée/documentée pour 26.7 pour l'instant.

Le chart `2026.3.1` déploie exactement SonarQube Community `26.5.0.122743`, qui matche
la version du plugin. Ça évite un éventuel bris (javaagent qui ne charge pas, UI branches
cassée) dû au décalage entre le plugin et l'image SonarQube.

## Test plan
- [ ] Vérifier que le pod sonarqube démarre correctement après sync ArgoCD
- [ ] Vérifier que le plugin community-branch se charge (logs `web`/`ce`, pas d'erreur javaagent)
- [ ] Vérifier l'UI de décoration de branches/PR