### PR TITLE
fix(jdgets-outlinewiki): move outline and redis PVCs to ceph-rbd

### DIFF
--- a/apps/clubs/jdgets/outlinewiki/base/outline-statefulset.yaml
+++ b/apps/clubs/jdgets/outlinewiki/base/outline-statefulset.yaml
@@ -90,4 +90,4 @@ spec:
         resources:
           requests:
             storage: 15Gi
-        storageClassName: cephfs
+        storageClassName: ceph-rbd

--- a/apps/clubs/jdgets/outlinewiki/base/redis-statefulset.yaml
+++ b/apps/clubs/jdgets/outlinewiki/base/redis-statefulset.yaml
@@ -84,4 +84,4 @@ spec:
         resources:
           requests:
             storage: 5Gi
-        storageClassName: cephfs
+        storageClassName: ceph-rbd


### PR DESCRIPTION
## Summary
- jdgets-outlinewiki-0 has had intermittent liveness/readiness probe failures over the past 11 days (`context deadline exceeded`, `connection refused` on `/_health`).
- Root cause: both `jdgets-outline-pv-claim` and `jdgets-redis-pv-claim` are on `cephfs`, which has a documented kernel client session corruption issue in this cluster (same root cause already fixed for `forgejo` and `nextcloud` via migration to `ceph-rbd`).
- Both PVCs are RWO single-consumer volumes and don't need RWX, so `ceph-rbd` is a valid target.

## Change
- `storageClassName: cephfs` → `ceph-rbd` for both PVC templates.

## Notes
- `volumeClaimTemplates.storageClassName` only affects new PVCs. Existing PVCs will be migrated by hand (data copied to new RBD volumes before the old cephfs ones are deleted) once this merges and ArgoCD syncs — tracked separately, not part of this PR's blast radius.

## Test plan
- [x] `kubectl kustomize apps/clubs/jdgets/outlinewiki/prod` renders cleanly with `ceph-rbd` in both PVC templates
- [x] Verified `ceph-rbd` StorageClass exists in `cedille-k8s-shared`
- [ ] After merge/sync: migrate existing PVC data to new RBD volumes, confirm outline app healthy with no probe failures