### PR TITLE
fix(dns): exclude internal HTTPProxy from external-dns

### DIFF
--- a/apps/authentik/resources/httpproxy.yaml
+++ b/apps/authentik/resources/httpproxy.yaml
@@ -32,6 +32,8 @@ apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
   name: authentik-internal
+  annotations:
+    external-dns.alpha.kubernetes.io/exclude: "true"
 spec:
   ingressClassName: contour-internal
   virtualhost:

--- a/apps/nextcloud/resources/httpproxy.yaml
+++ b/apps/nextcloud/resources/httpproxy.yaml
@@ -33,6 +33,8 @@ kind: HTTPProxy
 metadata:
   name: nextcloud-internal
   namespace: nextcloud
+  annotations:
+    external-dns.alpha.kubernetes.io/exclude: "true"
 spec:
   ingressClassName: contour-internal
   routes:
@@ -96,6 +98,8 @@ kind: HTTPProxy
 metadata:
   name: collabora-internal
   namespace: nextcloud
+  annotations:
+    external-dns.alpha.kubernetes.io/exclude: "true"
 spec:
   ingressClassName: contour-internal
   routes:


### PR DESCRIPTION
## Summary
- `auth.etsmtl.club` et `collabora-nextcloud.etsmtl.club` étaient injoignables publiquement : `external-dns` a re-créé ses enregistrements A/TXT ce matin (fix public-dns) et a choisi la cible `contour-internal` (`10.5.0.10`, pool MetalLB `internal-ip` actuellement absent) plutôt que la cible publique `142.137.247.75`, car les HTTPProxy `-internal` partagent le même FQDN que leur pendant public.
- Ajoute `external-dns.alpha.kubernetes.io/exclude: "true"` sur `authentik-internal`, `nextcloud-internal` et `collabora-internal` pour qu'external-dns n'ait plus qu'une seule source (publique) par hostname.
- `nextcloud-internal` corrigé préventivement (même risque, pas encore matérialisé).

## Test plan
- [ ] Après merge/sync ArgoCD, vérifier que `external-dns` republie `142.137.247.75` pour `auth.etsmtl.club` et `collabora-nextcloud.etsmtl.club`
- [ ] `dig auth.etsmtl.club` / `dig collabora-nextcloud.etsmtl.club` → `142.137.247.75`
- [ ] Vérifier accès HTTPS externe aux deux services