### PR TITLE
fix(campusparent): add missing Vault sync for b2-creds CNPG backup secret

### DIFF
--- a/apps/clubs/campusparent/website/prod/cnpg/kustomization.yml
+++ b/apps/clubs/campusparent/website/prod/cnpg/kustomization.yml
@@ -4,3 +4,4 @@ resources:
   - config-secret.yaml
   - random-secret.yaml
   - postgres.yaml
+  - vault.yaml

--- a/apps/clubs/campusparent/website/prod/cnpg/vault.yaml
+++ b/apps/clubs/campusparent/website/prod/cnpg/vault.yaml
@@ -1,0 +1,25 @@
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultAuth
+metadata:
+  name: campusparent-auth
+spec:
+  method: kubernetes
+  mount: kubernetes
+  kubernetes:
+    audiences:
+      - vault
+    role: secret-reader
+    serviceAccount: default
+---
+apiVersion: secrets.hashicorp.com/v1beta1
+kind: VaultStaticSecret
+metadata:
+  name: b2-creds
+spec:
+  vaultAuthRef: campusparent-auth
+  type: kv-v1
+  mount: kv-system
+  path: default_passwords/b2-creds
+  destination:
+    name: b2-creds
+    create: true


### PR DESCRIPTION
## Summary
- `postgresql-campusparent`'s CNPG barman-cloud backup config references a `b2-creds` secret that was never provisioned in the `campusparent` namespace — this has been missing since the cluster's creation (104 days), causing `ContinuousArchivingFailing` / `LastBackupFailed` continuously.
- Every other CNPG-with-barman namespace (forgejo, nextcloud, nextcloud-new, coder, outline clubs) has a matching `VaultAuth` + `VaultStaticSecret` pair syncing the same shared `kv-system/default_passwords/b2-creds` path — campusparent's directory was simply missing this manifest.
- Adds `apps/clubs/campusparent/website/prod/cnpg/vault.yaml` mirroring the exact pattern used by `nextcloud-new`/`coder`, and wires it into the kustomization.

## Test plan
- [x] `kubectl kustomize apps/clubs/campusparent/website/prod/cnpg` builds cleanly
- [ ] After merge/sync, confirm `kubectl get secret b2-creds -n campusparent` appears and `kubectl get cluster postgresql-campusparent -n campusparent` reports `ContinuousArchivingSuccess`/`LastBackupSucceeded` both True