### PR TITLE
fix(campusparent): migrate CNPG storage from cephfs to ceph-rbd

### DIFF
--- a/apps/clubs/campusparent/website/prod/cnpg/postgres.yaml
+++ b/apps/clubs/campusparent/website/prod/cnpg/postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgresql-campusparent
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.2
-  instances: 1
+  instances: 2
   bootstrap:
     initdb:
       database: campusparent
@@ -13,11 +13,11 @@ spec:
         name: postgresql-campusparent
   storage:
     size: 15Gi
-    storageClass: cephfs
+    storageClass: ceph-rbd
   backup:
     # needs a cleanup cronjob to delete old backups
     volumeSnapshot:
-      className: csi-cephfsplugin-snapclass
+      className: csi-ceph-rbd-snapclass
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true


### PR DESCRIPTION
## Summary
- `postgresql-campusparent` is the only remaining un-migrated CNPG cluster on the `cephfs` storage class. It hit the known CephFS kernel-client-corruption issue on 2026-08-17 (primary stuck 11 days in `CreateContainerError`/`permission denied`) — same root cause previously fixed for forgejo, nextcloud, and the outline-wiki clubs.
- Scales `instances: 1 -> 2` and switches `storage.storageClass: cephfs -> ceph-rbd` (and the volume-snapshot class to match) so CNPG provisions a new replica directly on ceph-rbd and streams it live from the current primary — no backup/restore dependency (backups are separately broken pending #344).
- Once merged and the new replica is healthy/streaming, I'll manually delete the old cephfs-backed primary's pod+PVCs to trigger failover, then follow up with a second PR to scale back down to `instances: 1`.

## Test plan
- [x] `kubectl kustomize apps/clubs/campusparent/website/prod/cnpg` builds cleanly
- [ ] After merge/sync, confirm a new `postgresql-campusparent-2` pod comes up `2/2 Running` on `ceph-rbd` and joins as a streaming replica
- [ ] After manual primary failover, confirm `kubectl get cluster postgresql-campusparent -n campusparent` shows `Cluster in healthy state` with the new instance as primary