### PR TITLE
feat(grav): porter le pattern grav + vault-gh-roles vers k8s-shared

### DIFF
--- a/.github/workflows/request-grav.yml
+++ b/.github/workflows/request-grav.yml
@@ -1,0 +1,129 @@
+name: Demander un site web GRAV
+
+on:
+  workflow_dispatch:
+    inputs:
+      domaine:
+        type: string
+        required: true
+        description: "Domaine à utiliser (eg cedille.etsmtl.ca)"
+      nom_club:
+        type: string
+        required: true
+        description: "Nom du club (lettres minuscules, chiffres et tirets '-' seulement). Pas de caractères spéciaux ou d'espaces outre - et _"
+      contexte:
+        type: string
+        required: false
+        description: "Contexte sur la demande"
+      skeleton_url:
+        type: string
+        required: false
+        description: "URL du squelette Grav (laisser vide pour le package de base). Voir https://getgrav.org/downloads/skeletons"
+
+jobs:
+  create_pr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      CLUB: ${{ inputs.nom_club }}
+      ROOT_DIR: apps/clubs/${{ inputs.nom_club }}/grav
+      PROD_DIR: apps/clubs/${{ inputs.nom_club }}/grav/prod
+      TEMPLATE_PROD_DIR: bases/grav/prod-templates
+      j2_vars: |
+        deployment_prefix=${{ inputs.nom_club }}
+        repo_name=${{ inputs.domaine }}
+        repo_url=https://github.com/ClubCedille/${{ inputs.domaine }}.git
+        namespace=${{ inputs.nom_club }}-grav
+        hostname=${{ inputs.domaine }}
+        requester=${{ github.event.sender.name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify nom_club input
+        run: |
+          if [[ ! "${{ inputs.nom_club }}" =~ ^[a-z0-9-]+$ ]]; then
+            echo "::error::ERREUR: Le nom du club '${{ inputs.nom_club }}' est invalide."
+            echo "::error::Il ne doit contenir que des lettres minuscules, des chiffres et des tirets (-)."
+            exit 1
+          fi
+
+      - name: Create k8s folder
+        run: mkdir -p "${{ env.PROD_DIR }}"
+
+      # -- PROD --
+      - name: Create Prod Kustomize
+        uses: cuchi/jinja2-action@v1.3.0
+        with:
+          template: ${{ env.TEMPLATE_PROD_DIR }}/kustomization.yaml.jinja2
+          output_file: ${{ env.PROD_DIR }}/kustomization.yaml
+          strict: true
+          variables: ${{ env.j2_vars }}
+
+      - name: Create vault-patch
+        uses: cuchi/jinja2-action@v1.3.0
+        with:
+          template: ${{ env.TEMPLATE_PROD_DIR }}/vault-patch.yaml.jinja2
+          output_file: ${{ env.PROD_DIR }}/vault-patch.yaml
+          strict: true
+          variables: ${{ env.j2_vars }}
+
+      # -- VAULT GITHUB ROLE --
+      - name: Create GitHub Secret Engine Role
+        uses: cuchi/jinja2-action@v1.3.0
+        with:
+          template: ${{ env.TEMPLATE_PROD_DIR }}/gh-role.yaml.jinja2
+          output_file: apps/vault-gh-roles/${{ inputs.nom_club }}-grav.yaml
+          strict: true
+          variables: ${{ env.j2_vars }}
+
+      - name: Update vault-gh-roles kustomization
+        run: |
+          cd apps/vault-gh-roles
+          if ! grep -q "${{ inputs.nom_club }}-grav.yaml" kustomization.yaml; then
+            yq eval '.resources += ["${{ inputs.nom_club }}-grav.yaml"]' -i kustomization.yaml
+          fi
+
+      # -- ARGO --
+      - name: Create Argo Manifest
+        uses: cuchi/jinja2-action@v1.3.0
+        with:
+          template: bases/grav/argoapp.yaml.jinja2
+          output_file: ${{ env.ROOT_DIR }}/${{ env.CLUB }}-grav.argoapp.yaml
+          strict: true
+          variables: ${{ env.j2_vars }}
+
+      # -- PR --
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "Créer un site web GRAV pour ${{ inputs.nom_club }}"
+          branch: grav/${{ inputs.nom_club }}
+          team-reviewers: |
+            SRE
+          labels: |
+            automated
+            grav
+            ${{ inputs.nom_club }}
+          body: |
+            PR automatisée pour la création d'un site web GRAV.
+
+            Nom du club: `${{ inputs.nom_club }}`
+            Domaine: `${{ inputs.domaine }}`
+            Contexte: ${{ inputs.contexte }}
+            Squelette: ${{ inputs.skeleton_url || 'Base Grav Admin (défaut)' }}
+
+            **Changements inclus:**
+            - Manifestes K8s (kustomize + Argo Application) dans `${{ env.ROOT_DIR }}`.
+            - Rôle Vault GitHub (`GitHubSecretEngineRole`) dans `apps/vault-gh-roles/${{ inputs.nom_club }}-grav.yaml`.
+
+            **Non inclus — à faire manuellement :**
+            - Création du repo GitHub `${{ inputs.domaine }}` (pas de Terraform GitHub côté k8s-shared, voir ClubCedille/k8s-cedille-production-v2#227).
+            - Repointage DNS de `${{ inputs.domaine }}`.
+
+            Mot de passe par défaut:
+            > `kubectl port-forward -n vault svc/vault-ui 8200`
+            > https://localhost:8200/ui/vault/secrets/kv/show/${{ inputs.nom_club }}-grav/default/grav/${{ inputs.nom_club }}-grav-init-pwd
+          token: ${{ secrets.PULL_REQUEST_TOKEN }}

--- a/apps/vault-gh-roles/kustomization.yaml
+++ b/apps/vault-gh-roles/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: vault
+
+resources: []

--- a/apps/vault-gh-roles/vault-gh-roles.argoapp.yaml
+++ b/apps/vault-gh-roles/vault-gh-roles.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault-gh-roles
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vault
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/vault-gh-roles
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=false
+    automated:
+      selfHeal: true
+      prune: true

--- a/bases/grav/argoapp.yaml.jinja2
+++ b/bases/grav/argoapp.yaml.jinja2
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ deployment_prefix }}-grav
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/clubcedille/grav:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: {{ namespace }}
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/{{ deployment_prefix }}/grav/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/bases/grav/config-secret.yaml
+++ b/bases/grav/config-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grav-config
+type: Opaque
+stringData:
+  GIT_VAULT_SECRET: gitsync
+  ADMIN_VAULT_SECRET: admin_pwd
+  SRE_VAULT_SECRET: sre_pwd

--- a/bases/grav/deployment.yaml
+++ b/bases/grav/deployment.yaml
@@ -1,0 +1,93 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: grav
+  name: grav
+  annotations:
+    kube-score/ignore: container-image-tag,container-security-context-readonlyrootfilesystem, container-security-context-user-group-id, pod-networkpolicy
+spec:
+  replicas: 1
+  minReadySeconds: 30
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: grav
+  template:
+    metadata:
+      labels:
+        app: grav
+    spec:
+      containers:
+        - name: grav
+          image: ghcr.io/clubcedille/grav:latest
+          imagePullPolicy: Always
+          env:
+            - name: HEAD_BRANCH
+              value: main
+          envFrom:
+            - secretRef:
+                name: grav-config
+          ports:
+            - containerPort: 8080
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+          volumeMounts:
+            - name: grav-accounts
+              mountPath: /var/www/html/user/accounts
+            - name: grav-data
+              mountPath: /var/www/html/user/data
+          resources:
+            requests:
+              cpu: 300m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+      securityContext:
+        # group 33 is www-data
+        runAsUser: 33
+        runAsGroup: 33
+        fsGroup: 33
+      volumes:
+        - name: grav-accounts
+          persistentVolumeClaim:
+            claimName: grav-accounts-pvc
+        - name: grav-data
+          persistentVolumeClaim:
+            claimName: grav-data-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grav-accounts-pvc
+spec:
+  storageClassName: cephfs
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "10Mi"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: grav-data-pvc
+spec:
+  storageClassName: cephfs
+  accessModes:
+    - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "10Mi"

--- a/bases/grav/kustomization.yaml
+++ b/bases/grav/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - network.yaml
+  - deployment.yaml
+  - random-secrets.yaml
+  - config-secret.yaml

--- a/bases/grav/network.yaml
+++ b/bases/grav/network.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grav
+spec:
+  ports:
+    - port: 80
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: grav
+---
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: grav-ingress
+spec:
+  virtualhost:
+    fqdn: grav.prod.cedille.club
+    tls:
+      secretName: grav-tls
+      minimumProtocolVersion: "1.3"
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: grav
+          port: 80
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: grav-tls
+spec:
+  secretName: grav-tls
+  issuerRef:
+    name: letsencrypt-staging
+    kind: ClusterIssuer
+  commonName: grav.prod.cedille.club
+  dnsNames:
+    - grav.prod.cedille.club

--- a/bases/grav/prod-templates/gh-role.yaml.jinja2
+++ b/bases/grav/prod-templates/gh-role.yaml.jinja2
@@ -1,0 +1,12 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GitHubSecretEngineRole
+metadata:
+  name: {{ deployment_prefix }}-grav
+spec:
+  authentication:
+    path: kubernetes
+    role: config-admin
+  path: github
+  repositories:
+    - {{repo_name}}
+  organizationName: ClubCedille

--- a/bases/grav/prod-templates/kustomization.yaml.jinja2
+++ b/bases/grav/prod-templates/kustomization.yaml.jinja2
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: {{ deployment_prefix }}-
+
+resources:
+  - ../../../../../bases/grav
+
+patches:
+  - path: vault-patch.yaml
+  - target:
+      kind: HTTPProxy
+      name: grav-ingress
+    patch: |-
+      - op: replace
+        path: /spec/virtualhost/fqdn
+        value: {{ hostname }}
+      - op: replace
+        path: /spec/virtualhost/tls/secretName
+        value: {{ deployment_prefix }}-grav-tls
+      - op: replace
+        path: /spec/routes/0/services/0/name
+        value: {{ deployment_prefix }}-grav
+  - target:
+      kind: Certificate
+      name: grav-tls
+    patch: |-
+      - op: replace
+        path: /spec/secretName
+        value: {{ deployment_prefix }}-grav-tls
+      - op: replace
+        path: /spec/commonName
+        value: {{ hostname }}
+      - op: replace
+        path: /spec/dnsNames/0
+        value: {{ hostname }}
+      - op: replace
+        path: /spec/issuerRef/name
+        value: letsencrypt-http
+  - target:
+      kind: RandomSecret
+    patch: |-
+      - op: replace
+        path: /spec/path
+        value: kv/data/{{ namespace }}/default/grav

--- a/bases/grav/prod-templates/vault-patch.yaml.jinja2
+++ b/bases/grav/prod-templates/vault-patch.yaml.jinja2
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grav
+spec:
+  template:
+    metadata:
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "secret-reader"
+        vault.hashicorp.com/agent-inject-template-gitsync: |
+          {{'{{'}}- with secret "github/token/{{ deployment_prefix }}-grav" -{{'}}'}}
+          enabled: true
+          folders:
+            - pages
+            - plugins
+            - themes
+            - config
+          SyncNotice: null
+          sync:
+            on_save: true
+            on_delete: true
+            on_media: true
+            cron_enable: true
+            cron_at: '*/10 * * * *'
+          local_repository: null
+          repository: '{{repo_url}}'
+          no_user: '0'
+          user: x-access-token
+          password: "{{'{{ .Data.token }}'}}"
+          webhook_enabled: '1'
+          webhook: '/_git_webhook'
+          branch: main
+          remote:
+            name: origin
+            branch: main
+          git:
+            author: gitsync
+            message: '(Grav GitSync) Automatic Commit'
+            name: GitSync
+            email: git-sync@trilby.media
+            bin: git
+            ignore: null
+            private_key: null
+          logging: true
+          {{'{{- end }}'}}
+        vault.hashicorp.com/agent-inject-template-admin_pwd: |
+          {{'{{'}}- with secret "kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-init-pwd" -{{'}}'}}
+          state: enabled
+          email: admin@{{hostname}}
+          username: admin
+          fullname: admin
+          title: Administrator
+          access:
+            admin:
+              login: true
+              super: true
+            site:
+              login: true
+          password: "{{'{{ .Data.data.password }}'}}"
+          {{'{{- end }}'}}
+        vault.hashicorp.com/agent-inject-template-sre_pwd: |
+          {{'{{'}}- with secret "kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-sre-pwd" -{{'}}'}}
+          state: enabled
+          email: sre@cedille.club
+          username: sre
+          fullname: SRE
+          title: SRE
+          access:
+            admin:
+              login: true
+              super: true
+            site:
+              login: true
+          password: "{{'{{ .Data.data.password }}'}}"
+          {{'{{- end }}'}}
+        vault.hashicorp.com/agent-inject-template-salt: |
+          {{'{{'}}- with secret "kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-salt" -{{'}}'}}
+          salt: "{{'{{ .Data.data.salt }}'}}"
+          {{'{{- end }}'}}

--- a/bases/grav/random-secrets.yaml
+++ b/bases/grav/random-secrets.yaml
@@ -1,0 +1,41 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: RandomSecret
+metadata:
+  name: grav-init-pwd
+spec:
+  authentication:
+    path: kubernetes
+    role: secret-writer
+  isKVSecretsEngineV2: true
+  path: grav-init-pwd
+  secretKey: password
+  secretFormat:
+    passwordPolicyName: password-policy
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: RandomSecret
+metadata:
+  name: grav-sre-pwd
+spec:
+  authentication:
+    path: kubernetes
+    role: secret-writer
+  isKVSecretsEngineV2: true
+  path: grav-sre-pwd
+  secretKey: password
+  secretFormat:
+    passwordPolicyName: password-policy
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: RandomSecret
+metadata:
+  name: grav-salt
+spec:
+  authentication:
+    path: kubernetes
+    role: secret-writer
+  isKVSecretsEngineV2: true
+  path: grav-salt
+  secretKey: salt
+  secretFormat:
+    passwordPolicyName: password-policy


### PR DESCRIPTION
## Contexte

Prérequis bloquant pour la migration de `crabe` (crabeweb-grav) et `raconteurs` (raconteurs-grav) de `production-v2` vers `k8s-shared` (cf. [méta-issue #230](https://github.com/ClubCedille/k8s-cedille-production-v2/issues/230)).

Ferme (une fois validé) : ClubCedille/k8s-cedille-production-v2#227, ClubCedille/k8s-cedille-production-v2#229

## Ce qui est prêt

- `bases/grav/` : base Kustomize (Deployment, PVCs cephfs, RandomSecrets, HTTPProxy, Certificate, Secret) copiée telle quelle depuis `k8s-cedille-production-v2/bases/grav/`.
- `bases/grav/prod-templates/*.jinja2` : templates adaptés pour k8s-shared (`project: k8s-shared`, `destination.server: https://kubernetes.default.svc`, chemin `apps/clubs/<club>/grav/prod`), sur le modèle de `bases/outlinewiki/`.
  - Ajout d'un patch `issuerRef.name: letsencrypt-http` explicite dans `kustomization.yaml.jinja2` (absent du template original, mais présent manuellement dans l'instance `raconteurs` réelle — désormais généré automatiquement).
- `bases/grav/argoapp.yaml.jinja2` : Application ArgoCD, au même niveau que `bases/outlinewiki/argoapp.yaml.jinja2`.
- `apps/vault-gh-roles/` : plumbing Vault (`GitHubSecretEngineRole`) — kustomization vide prête à recevoir les rôles générés par le workflow, + Application ArgoCD (`sync-wave: "1"`, comme dans production-v2).
- `.github/workflows/request-grav.yml` : workflow `workflow_dispatch` adapté de production-v2, génère les manifestes + le rôle Vault GitHub + la PR.
- Validé localement : rendu Jinja2 manuel (substitution des variables) + `kubectl kustomize` sur une instance de test (`testclub`) — patches fqdn/secretName/issuerRef/path Vault appliqués correctement, pas de syntaxe Jinja2 résiduelle en dehors des templates Vault Go (attendu).
- Vérifié sur le cluster réel (`kubectl --context=cedille-k8s-shared`) : `vault-agent-injector` et le CRD `githubsecretengineroles.redhatcop.redhat.io` (vault-config-operator) tournent déjà — aucun nouvel opérateur à installer.

## Ce qui n'est PAS inclus (décision opérateur)

- **Terraform GitHub (`grav-repo.tf.jinja2`)** : non porté. `k8s-shared/terraform/` n'a qu'un provider Authentik (OpenTofu local + `apply-tf.yml`), alors que `production-v2/terraform/github/` utilise Terraform Cloud avec un GitHub App dédié. Décision : ne pas migrer cette partie pour l'instant — la création du repo GitHub d'un site Grav reste manuelle. Le workflow `request-grav.yml` documente ce point dans le corps de la PR qu'il génère.

## Reste à valider manuellement avant de fermer #227/#229

- [ ] Tester `request-grav.yml` en conditions réelles (`workflow_dispatch`) sur un club de test, vérifier que la PR générée est cohérente.
- [ ] Confirmer que `vault-agent-injector` a bien accès au path `github/token/<club>-grav` (rôle Vault `secret-reader` / `config-admin`) — dépend du rôle Vault déjà configuré pour production-v2, à vérifier qu'il couvre aussi k8s-shared.
- [ ] Décider qui crée effectivement les repos GitHub des sites Grav tant que Terraform n'est pas branché (processus manuel à documenter).
- [ ] Ne pas synchroniser `vault-gh-roles.argoapp.yaml` avant d'avoir au moins un club réel dans `apps/vault-gh-roles/kustomization.yaml` (actuellement `resources: []`, plumbing seule).

Aucune action appliquée contre le cluster réel — travail préparatoire uniquement (fichiers + PR).