### PR TITLE
fix(dns): exclude internal HTTPProxy from external-dns

### DIFF
--- a/apps/authentik/resources/httpproxy.yaml
+++ b/apps/authentik/resources/httpproxy.yaml
@@ -32,6 +32,8 @@ apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
   name: authentik-internal
+  annotations:
+    external-dns.alpha.kubernetes.io/exclude: "true"
 spec:
   ingressClassName: contour-internal
   virtualhost:

--- a/apps/nextcloud/resources/httpproxy.yaml
+++ b/apps/nextcloud/resources/httpproxy.yaml
@@ -33,6 +33,8 @@ kind: HTTPProxy
 metadata:
   name: nextcloud-internal
   namespace: nextcloud
+  annotations:
+    external-dns.alpha.kubernetes.io/exclude: "true"
 spec:
   ingressClassName: contour-internal
   routes:
@@ -96,6 +98,8 @@ kind: HTTPProxy
 metadata:
   name: collabora-internal
   namespace: nextcloud
+  annotations:
+    external-dns.alpha.kubernetes.io/exclude: "true"
 spec:
   ingressClassName: contour-internal
   routes:


### PR DESCRIPTION
## Summary
Reopens what #343 did, now confirmed as still necessary after ClubCedille/k8s-base#62.

- #62 fixed `ingressClassFilters` on external-dns (`contour-external` instead of `contour-internal`), but that flag (`--ingress-class`) only filters the `ingress` source in external-dns v0.20.0, not `contour-httpproxy`. It fixed `planka.etsmtl.club` (which conflicted with a stale ACME solver `Ingress`), but `auth.etsmtl.club` and `collabora-nextcloud.etsmtl.club` (which conflict with a duplicate **HTTPProxy**, `authentik-internal`/`collabora-internal`) are still unaffected — confirmed via `dig` (still `10.5.0.10`) and external-dns logs (`"All records are already up to date"`, i.e. it still considers the internal HTTPProxy a valid source).
- Adds `external-dns.alpha.kubernetes.io/exclude: "true"` on `authentik-internal`, `nextcloud-internal` and `collabora-internal` so external-dns has only one candidate source per hostname regardless of which source type is involved.

## Test plan
- [ ] After sync, `dig auth.etsmtl.club` / `dig collabora-nextcloud.etsmtl.club` → `142.137.247.75`
- [ ] Verify external HTTPS access to both services