### PR TITLE
fix(dns): rename internal HTTPProxy to sort before their public twin

### DIFF
--- a/apps/authentik/resources/httpproxy.yaml
+++ b/apps/authentik/resources/httpproxy.yaml
@@ -31,7 +31,7 @@ spec:
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
-  name: authentik-internal
+  name: 0-authentik-internal
   annotations:
     external-dns.alpha.kubernetes.io/exclude: "true"
 spec:

--- a/apps/nextcloud-new/resources/httpproxy.yaml
+++ b/apps/nextcloud-new/resources/httpproxy.yaml
@@ -31,7 +31,7 @@ spec:
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
-  name: nextcloud-internal
+  name: 0-nextcloud-internal
   namespace: nextcloud-new
   annotations:
     external-dns.alpha.kubernetes.io/exclude: "true"
@@ -96,7 +96,7 @@ spec:
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
-  name: collabora-internal
+  name: 0-collabora-internal
   namespace: nextcloud-new
   annotations:
     external-dns.alpha.kubernetes.io/exclude: "true"

--- a/apps/nextcloud/resources/httpproxy.yaml
+++ b/apps/nextcloud/resources/httpproxy.yaml
@@ -31,7 +31,7 @@ spec:
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
-  name: nextcloud-internal
+  name: 0-nextcloud-internal
   namespace: nextcloud
   annotations:
     external-dns.alpha.kubernetes.io/exclude: "true"
@@ -96,7 +96,7 @@ spec:
 apiVersion: projectcontour.io/v1
 kind: HTTPProxy
 metadata:
-  name: collabora-internal
+  name: 0-collabora-internal
   namespace: nextcloud
   annotations:
     external-dns.alpha.kubernetes.io/exclude: "true"


### PR DESCRIPTION
## Summary
- #62 and #348 both failed to fix `auth.etsmtl.club` / `collabora-nextcloud.etsmtl.club`: confirmed live that external-dns's `contour-httpproxy` source in v0.20.0 respects neither `ingressClassFilters` nor the `external-dns.alpha.kubernetes.io/exclude` annotation. When two HTTPProxy share a FQDN, it deterministically keeps the one with the lexicographically greater resource name (`authentik-internal` over `authentik`, `collabora-internal` over `collabora`) — reproduced twice, including after manually clearing the stale Cloudflare records this morning's incident created.
- Renames `authentik-internal` → `0-authentik-internal`, `nextcloud-internal` → `0-nextcloud-internal`, `collabora-internal` → `0-collabora-internal` so they sort before their public counterpart, flipping the pick.
- Internal-only routing behavior is unchanged (still `contour-internal` class, same routes/services) — only the k8s object name changes, so ArgoCD will delete+recreate these three HTTPProxy on sync.
- Note for follow-up: `apps/nextcloud-new/resources/httpproxy.yaml` (the nextcloud migration in progress) has the same `nextcloud-internal`/`collabora-internal` naming and will hit the same bug once it's live — not touched here since it's not yet in production, but worth applying the same rename before cutover.

## Test plan
- [ ] After sync, `dig auth.etsmtl.club` / `dig collabora-nextcloud.etsmtl.club` → `142.137.247.75`
- [ ] Verify external HTTPS access to both services
- [ ] Once the `internal-ip` MetalLB pool is restored, verify internal-only access to auth/nextcloud/collabora still works via the renamed HTTPProxy