### PR TITLE
fix(campusparent): scale back to 1 instance after ceph-rbd migration

### DIFF
--- a/apps/clubs/campusparent/website/prod/cnpg/postgres.yaml
+++ b/apps/clubs/campusparent/website/prod/cnpg/postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgresql-campusparent
 spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:17.2
-  instances: 2
+  instances: 1
   bootstrap:
     initdb:
       database: campusparent


### PR DESCRIPTION
## Summary
- Follow-up to #345 (merged). The ceph-rbd migration is confirmed done: `postgresql-campusparent-2` was promoted to primary and is healthy, a fresh `postgresql-campusparent-3` replica is streaming, both on `ceph-rbd`. The old cephfs-backed `postgresql-campusparent-1` pod+PVC were deleted to trigger the failover.
- This scales `instances` back down from `2` to `1`, matching the cluster's original topology (it was never intended to run HA) now that the temporary second instance used for the live migration has done its job.

## Test plan
- [x] `kubectl kustomize apps/clubs/campusparent/website/prod/cnpg` builds cleanly
- [ ] After merge/sync, confirm the cluster scales to 1 instance and `kubectl get cluster postgresql-campusparent -n campusparent` still reports `Cluster in healthy state`