### PR TITLE
Conjure: migrate website to k8s-shared

### DIFF
--- a/apps/clubs/conjure/website/base/deployment.yaml
+++ b/apps/clubs/conjure/website/base/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: conjure-service
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: conjure-service
+  template:
+    metadata:
+      labels:
+        app: conjure-service
+    spec:
+      containers:
+        - name: conjure-service
+          image: ghcr.io/conjureets/conjure-site:latest
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: run-dir
+              mountPath: /run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          ports:
+            - containerPort: 80
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: run-dir
+          emptyDir: {}

--- a/apps/clubs/conjure/website/base/kustomization.yaml
+++ b/apps/clubs/conjure/website/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml

--- a/apps/clubs/conjure/website/base/network.yaml
+++ b/apps/clubs/conjure/website/base/network.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: conjure-service
+spec:
+  ports:
+    - name: http
+      targetPort: 80
+      protocol: TCP
+      port: 80
+  type: ClusterIP
+  selector:
+    app: conjure-service

--- a/apps/clubs/conjure/website/conjure-shared.argoapp.yaml
+++ b/apps/clubs/conjure/website/conjure-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: conjure
+  name: conjure-shared
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"

--- a/apps/clubs/conjure/website/conjure.argoapp.yaml
+++ b/apps/clubs/conjure/website/conjure.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: conjure
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: webapp=ghcr.io/conjureets/conjure-site:latest
+    argocd-image-updater.argoproj.io/webapp.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: conjure-site
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/conjure/website/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/conjure/website/prod/ingress.yaml
+++ b/apps/clubs/conjure/website/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: conjure-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - conjure.etsmtl.ca
+      secretName: conjure-cert-tls
+  rules:
+    - host: conjure.etsmtl.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: conjure-service
+                port:
+                  name: http

--- a/apps/clubs/conjure/website/prod/ingress.yaml
+++ b/apps/clubs/conjure/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: conjure-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-http
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/conjure/website/prod/kustomization.yaml
+++ b/apps/clubs/conjure/website/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml


### PR DESCRIPTION
Port du site statique conjure de k8s-cedille-production-v2 vers k8s-shared. Résout #223.