### PR TITLE
Cedille: migrate website to k8s-shared

### DIFF
--- a/apps/clubs/cedille/website/base/configMap.yaml
+++ b/apps/clubs/cedille/website/base/configMap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  custom-nginx.conf: |
+    server {
+      listen 8080;
+      location / {
+          root /usr/share/nginx/html;
+          index index.html index.htm;
+      }
+    }

--- a/apps/clubs/cedille/website/base/deployment.yaml
+++ b/apps/clubs/cedille/website/base/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cedille
+  annotations:
+    kube-score/ignore: container-image-pull-policy,container-image-tag, pod-networkpolicy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: cedille
+  template:
+    metadata:
+      labels:
+        app: cedille
+    spec:
+      containers:
+        - name: cedille
+          image: ghcr.io/clubcedille/cedille.etsmtl.ca:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: nginx-temp
+              mountPath: /var/cache/nginx
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: run-volume
+              mountPath: /var/run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+      volumes:
+        - name: nginx-temp
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: nginx-config
+        - name: run-volume
+          emptyDir: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cedille-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: cedille

--- a/apps/clubs/cedille/website/base/kustomization.yaml
+++ b/apps/clubs/cedille/website/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configMap.yaml

--- a/apps/clubs/cedille/website/base/service.yaml
+++ b/apps/clubs/cedille/website/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cedille-service
+spec:
+  ports:
+    - name: http
+      targetPort: 8080
+      protocol: TCP
+      port: 80
+  type: ClusterIP
+  selector:
+    app: cedille

--- a/apps/clubs/cedille/website/cedille-shared.argoapp.yaml
+++ b/apps/clubs/cedille/website/cedille-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: cedille
+  name: cedille-shared
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"

--- a/apps/clubs/cedille/website/cedille.argoapp.yaml
+++ b/apps/clubs/cedille/website/cedille.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cedille
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: webapp=ghcr.io/clubcedille/cedille.etsmtl.ca:latest
+    argocd-image-updater.argoproj.io/webapp.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: cedille
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/cedille/website/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/cedille/website/prod/ingress.yaml
+++ b/apps/clubs/cedille/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: cedille
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-http
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/cedille/website/prod/ingress.yaml
+++ b/apps/clubs/cedille/website/prod/ingress.yaml
@@ -1,0 +1,51 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cedille
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - cedille.etsmtl.ca
+      secretName: cedille-cert-tls
+  rules:
+    - host: cedille.etsmtl.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cedille-service
+                port:
+                  name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: cedille-prod
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - cedille.prodv2.cedille.club
+      secretName: cedille-cert-tls-prod
+  rules:
+    - host: cedille.prodv2.cedille.club
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: cedille-service
+                port:
+                  name: http

--- a/apps/clubs/cedille/website/prod/kustomization.yaml
+++ b/apps/clubs/cedille/website/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml


### PR DESCRIPTION
Port du site principal du club Cedille de k8s-cedille-production-v2 vers k8s-shared. Résout #205.