### PR TITLE
fix(nextcloud-new): temporarily pin replicaCount to 1 for initial install

### DIFF
--- a/apps/nextcloud-new/helm/nextcloud-values.yaml
+++ b/apps/nextcloud-new/helm/nextcloud-values.yaml
@@ -11,7 +11,11 @@ image:
   pullSecrets:
     - dockerhub-pull
 # Number of replicas to be deployed
-replicaCount: 3
+# TEMPORARY: pinned to 1 during initial install — the docker image's entrypoint uses a
+# flock-based lock on the shared RWX PVC to serialize concurrent first-boot installs across
+# replicas, but on a fresh CephFS-backed PVC this repeatedly crash-looped instead of
+# converging. Revert to 3 once `occ status` confirms installed:true.
+replicaCount: 1
 ## Allowing use of ingress controllers
 ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##


### PR DESCRIPTION
## Summary
- The 3-replica nextcloud-new deployment crash-looped on first boot: all replicas race to initialize the shared RWX PVC, and the docker image's flock-based serialization didn't converge (restart counts kept climbing instead of stabilizing).
- Pins `replicaCount: 1` temporarily so a single pod can complete the install cleanly.
- Follow-up PR will revert to 3 once `occ status` confirms `installed: true`.

## Test plan
- [ ] ArgoCD syncs, single replica completes install without crash-looping
- [ ] `installed: true` confirmed
- [ ] Follow-up revert PR opened