### PR TITLE
Wiki-Cedille: migrate to k8s-shared

### DIFF
--- a/apps/clubs/cedille/wiki-cedille/base/configMap.yaml
+++ b/apps/clubs/cedille/wiki-cedille/base/configMap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  custom-nginx.conf: |
+    server {
+        listen 0.0.0.0:8080;
+        server_name _;
+
+        absolute_redirect off;
+
+        location / {
+            alias /app/fr/;
+            try_files $uri $uri/ /fr/index.html;
+        }
+
+        location /en/ {
+            alias /app/en/;
+            try_files $uri $uri/ /en/index.html;
+        }
+    }

--- a/apps/clubs/cedille/wiki-cedille/base/deployment.yaml
+++ b/apps/clubs/cedille/wiki-cedille/base/deployment.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wiki-cedille
+  annotations:
+    kube-score/ignore: container-image-tag, pod-networkpolicy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wiki-cedille
+  template:
+    metadata:
+      labels:
+        app: wiki-cedille
+    spec:
+      containers:
+        - name: wiki-cedille
+          image: ghcr.io/clubcedille/wiki-cedille:latest
+          imagePullPolicy: Always
+          env:
+            - name: NGINX_ENABLE_ABSOLUTE_REDIRECT
+              value: "yes"
+            - name: NGINX_ENABLE_PORT_IN_REDIRECT
+              value: "yes"
+            - name: NGINX_HTTP_PORT_NUMBER
+              value: "8080"
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: nginx-temp
+              mountPath: /var/cache/nginx
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: run-volume
+              mountPath: /var/run
+      volumes:
+        - name: nginx-temp
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: nginx-config
+        - name: run-volume
+          emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wiki-cedille-stg
+  annotations:
+    kube-score/ignore: container-image-tag, pod-networkpolicy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wiki-cedille-stg
+  template:
+    metadata:
+      labels:
+        app: wiki-cedille-stg
+    spec:
+      containers:
+        - name: wiki-cedille-stg
+          image: ghcr.io/clubcedille/wiki-cedille:staging
+          imagePullPolicy: Always
+          env:
+            - name: NGINX_ENABLE_ABSOLUTE_REDIRECT
+              value: "yes"
+            - name: NGINX_ENABLE_PORT_IN_REDIRECT
+              value: "yes"
+            - name: NGINX_HTTP_PORT_NUMBER
+              value: "8080"
+          ports:
+            - containerPort: 8080
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: nginx-temp
+              mountPath: /var/cache/nginx
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: run-volume
+              mountPath: /var/run
+      volumes:
+        - name: nginx-temp
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: nginx-config
+        - name: run-volume
+          emptyDir: {}

--- a/apps/clubs/cedille/wiki-cedille/base/kustomization.yaml
+++ b/apps/clubs/cedille/wiki-cedille/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml
+  - configMap.yaml

--- a/apps/clubs/cedille/wiki-cedille/base/network.yaml
+++ b/apps/clubs/cedille/wiki-cedille/base/network.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wiki-cedille
+spec:
+  selector:
+    app: wiki-cedille
+  ports:
+    - name: http
+      targetPort: 8080
+      protocol: TCP
+      port: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: wiki-cedille-stg
+spec:
+  selector:
+    app: wiki-cedille-stg
+  ports:
+    - name: http
+      targetPort: 8080
+      protocol: TCP
+      port: 80
+  type: ClusterIP

--- a/apps/clubs/cedille/wiki-cedille/prod/ingress.yaml
+++ b/apps/clubs/cedille/wiki-cedille/prod/ingress.yaml
@@ -1,0 +1,51 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wiki-cedille-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: wiki-tls
+      hosts:
+        - wiki.cedille.club
+  rules:
+    - host: wiki.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: wiki-cedille
+                port:
+                  name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wiki-cedille-ingress-stg
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: wiki-stg-tls
+      hosts:
+        - wiki.prodv2.cedille.club
+  rules:
+    - host: wiki.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: wiki-cedille-stg
+                port:
+                  name: http

--- a/apps/clubs/cedille/wiki-cedille/prod/kustomization.yaml
+++ b/apps/clubs/cedille/wiki-cedille/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/
+  - ingress.yaml

--- a/apps/clubs/cedille/wiki-cedille/wiki-cedille-shared.argoapp.yaml
+++ b/apps/clubs/cedille/wiki-cedille/wiki-cedille-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: wiki-cedille
+  name: wiki-cedille-shared
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"

--- a/apps/clubs/cedille/wiki-cedille/wiki-cedille.argoapp.yaml
+++ b/apps/clubs/cedille/wiki-cedille/wiki-cedille.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: wiki-cedille
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: wiki=ghcr.io/clubcedille/wiki-cedille:latest
+    argocd-image-updater.argoproj.io/wiki.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: wiki-cedille
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/cedille/wiki-cedille/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: false
+      prune: false


### PR DESCRIPTION
Port du wiki du club Cedille de k8s-cedille-production-v2 vers k8s-shared. Résout #222.