### PR TITLE
ETSHub: migrate website to k8s-shared

### DIFF
--- a/apps/clubs/etshub/website/base/deployment.yaml
+++ b/apps/clubs/etshub/website/base/deployment.yaml
@@ -1,0 +1,74 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: etshub
+  annotations:
+    kube-score/ignore: pod-networkpolicy,container-image-tag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etshub
+  template:
+    metadata:
+      labels:
+        app: etshub
+    spec:
+      securityContext:
+        fsGroup: 10001
+        fsGroupChangePolicy: OnRootMismatch
+      imagePullSecrets:
+        - name: ghcr-clubcedille-secret
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: etshub
+          image: ghcr.io/clubcedille/etshub:latest
+          imagePullPolicy: Always
+          env:
+            - name: RESEND_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: etshub-secret
+                  key: RESEND_API_KEY
+                  optional: true
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /manifest.webmanifest
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+            timeoutSeconds: 5
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/clubs/etshub/website/base/kustomization.yaml
+++ b/apps/clubs/etshub/website/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/apps/clubs/etshub/website/base/service.yaml
+++ b/apps/clubs/etshub/website/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: etshub-svc
+spec:
+  selector:
+    app: etshub
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/apps/clubs/etshub/website/etshub-shared.argoapp.yaml
+++ b/apps/clubs/etshub/website/etshub-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: etshub
+  name: etshub-shared
   namespace: argocd
   annotations:
     argocd-image-updater.argoproj.io/image-list: etshub=ghcr.io/clubcedille/etshub:latest

--- a/apps/clubs/etshub/website/etshub.argoapp.yaml
+++ b/apps/clubs/etshub/website/etshub.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: etshub
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: etshub=ghcr.io/clubcedille/etshub:latest
+    argocd-image-updater.argoproj.io/etshub.update-strategy: digest
+    argocd-image-updater.argoproj.io/etshub.pull-secret: pullsecret:argocd/ghcr-clubcedille-secret
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: etshub
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/etshub/website/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/etshub/website/prod/ingress.yaml
+++ b/apps/clubs/etshub/website/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: etshub
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: etshub-tls
+      hosts:
+        - etshub.prodv2.cedille.club
+  rules:
+    - host: etshub.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: etshub-svc
+                port:
+                  number: 80

--- a/apps/clubs/etshub/website/prod/ingress.yaml
+++ b/apps/clubs/etshub/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: etshub
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-http
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/etshub/website/prod/kustomization.yaml
+++ b/apps/clubs/etshub/website/prod/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/
+  - ingress.yaml
+  - vault-secret.yaml

--- a/apps/clubs/etshub/website/prod/vault-secret.yaml
+++ b/apps/clubs/etshub/website/prod/vault-secret.yaml
@@ -1,0 +1,39 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: ghcr-clubcedille-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: docker
+      path: kv-system/default_passwords/docker
+  output:
+    name: ghcr-clubcedille-secret
+    stringData:
+      .dockerconfigjson: '{{ b64dec .docker.config }}'
+    type: kubernetes.io/dockerconfigjson
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: etshub-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: etshub
+      path: kv/data/etshub/default/config
+  output:
+    name: etshub-secret
+    stringData:
+      RESEND_API_KEY: '{{ .etshub.resend_api_key }}'
+    type: opaque


### PR DESCRIPTION
Port du site ETSHub de k8s-cedille-production-v2 vers k8s-shared. Résout #209.