### PR TITLE
Ingénieuses: migrate website to k8s-shared

### DIFF
--- a/apps/clubs/ingenieuses/website/base/deployment.yaml
+++ b/apps/clubs/ingenieuses/website/base/deployment.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingenieuses
+  annotations:
+    kube-score/ignore: pod-networkpolicy,container-image-tag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingenieuses
+  template:
+    metadata:
+      labels:
+        app: ingenieuses
+    spec:
+      imagePullSecrets:
+        - name: ghcr-ingenieuses-secret
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+      containers:
+        - name: ingenieuses
+          image: ghcr.io/les-ingenieuses-de-l-ets/web-ingenieuses:latest
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-run
+              mountPath: /run
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/clubs/ingenieuses/website/base/kustomization.yaml
+++ b/apps/clubs/ingenieuses/website/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - service.yaml
+  - deployment.yaml

--- a/apps/clubs/ingenieuses/website/base/service.yaml
+++ b/apps/clubs/ingenieuses/website/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ingenieuses-svc
+spec:
+  selector:
+    app: ingenieuses
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/apps/clubs/ingenieuses/website/ingenieuses-shared.argoapp.yaml
+++ b/apps/clubs/ingenieuses/website/ingenieuses-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: ingenieuses
+  name: ingenieuses-shared
   namespace: argocd
   annotations:
     argocd-image-updater.argoproj.io/image-list: webapp=ghcr.io/les-ingenieuses-de-l-ets/web-ingenieuses:latest

--- a/apps/clubs/ingenieuses/website/ingenieuses.argoapp.yaml
+++ b/apps/clubs/ingenieuses/website/ingenieuses.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ingenieuses
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: webapp=ghcr.io/les-ingenieuses-de-l-ets/web-ingenieuses:latest
+    argocd-image-updater.argoproj.io/webapp.update-strategy: digest
+    argocd-image-updater.argoproj.io/webapp.pull-secret: pullsecret:argocd/ghcr-ingenieuses-secret
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ingenieuses
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/ingenieuses/website/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/ingenieuses/website/prod/ingress.yaml
+++ b/apps/clubs/ingenieuses/website/prod/ingress.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingenieuses
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: ingenieuses-tls
+      hosts:
+        - ingenieuses.ca
+        - www.ingenieuses.ca
+  rules:
+    - host: ingenieuses.ca
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: ingenieuses-svc
+                port:
+                  number: 80
+    - host: www.ingenieuses.ca
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: ingenieuses-svc
+                port:
+                  number: 80

--- a/apps/clubs/ingenieuses/website/prod/ingress.yaml
+++ b/apps/clubs/ingenieuses/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: ingenieuses
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-http
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/ingenieuses/website/prod/kustomization.yaml
+++ b/apps/clubs/ingenieuses/website/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/
+  - ingress.yaml


### PR DESCRIPTION
Port du site Ingénieuses de k8s-cedille-production-v2 vers k8s-shared.

> Note: le pull secret `ghcr-ingenieuses-secret` doit exister dans le namespace `ingenieuses` (il est déjà présent dans le namespace `argocd`). Résout #212.