### PR TITLE
Intégrale: migrate website to k8s-shared

### DIFF
--- a/apps/clubs/integrale/website/base/deployment.yaml
+++ b/apps/clubs/integrale/website/base/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: integrale-website
+  annotations:
+    kube-score/ignore: container-image-pull-policy,container-image-tag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: integrale-website
+  template:
+    metadata:
+      labels:
+        app: integrale-website
+    spec:
+      containers:
+        - name: integrale-website
+          image: ghcr.io/integrale-ets/site-integrale:latest
+          imagePullPolicy: Always
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          ports:
+            - containerPort: 3000
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: yarn-tmp
+              mountPath: /tmp
+            - name: yarn-global
+              mountPath: /usr/local/share/.cache/yarn
+      volumes:
+        - name: yarn-tmp
+          emptyDir: {}
+        - name: yarn-global
+          emptyDir: {}

--- a/apps/clubs/integrale/website/base/kustomization.yaml
+++ b/apps/clubs/integrale/website/base/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml

--- a/apps/clubs/integrale/website/base/network.yaml
+++ b/apps/clubs/integrale/website/base/network.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: integrale-website-svc
+spec:
+  selector:
+    app: integrale-website
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/apps/clubs/integrale/website/integrale-website-shared.argoapp.yaml
+++ b/apps/clubs/integrale/website/integrale-website-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: integrale-website
+  name: integrale-website-shared
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"

--- a/apps/clubs/integrale/website/integrale.argoapp.yaml
+++ b/apps/clubs/integrale/website/integrale.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: integrale-website
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/integrale-ets/site-integrale:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: integrale-website
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/integrale/website/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/integrale/website/prod/ingress.yaml
+++ b/apps/clubs/integrale/website/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: integrale-website-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - integrale.etsmtl.ca
+      secretName: integrale-website-tls
+  rules:
+    - host: integrale.etsmtl.ca
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: integrale-website-svc
+                port:
+                  number: 3000

--- a/apps/clubs/integrale/website/prod/ingress.yaml
+++ b/apps/clubs/integrale/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: integrale-website-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-http
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/integrale/website/prod/kustomization.yaml
+++ b/apps/clubs/integrale/website/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/
+  - ingress.yaml


### PR DESCRIPTION
Port du site Intégrale de k8s-cedille-production-v2 vers k8s-shared. Résout #213.