### PR TITLE
Synapsets: migrate website to k8s-shared

### DIFF
--- a/apps/clubs/synapsets/website/base/configMap.yaml
+++ b/apps/clubs/synapsets/website/base/configMap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  custom-nginx.conf: |
+    server {
+      listen 8080;
+      location / {
+          root /usr/share/nginx/html;
+          index index.html index.htm;
+      }
+    }

--- a/apps/clubs/synapsets/website/base/deployment.yaml
+++ b/apps/clubs/synapsets/website/base/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: synapsets
+  annotations:
+    kube-score/ignore: container-image-pull-policy,container-image-tag, pod-networkpolicy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: synapsets
+  template:
+    metadata:
+      labels:
+        app: synapsets
+    spec:
+      containers:
+        - name: synapsets
+          image: ghcr.io/clubcedille/synapsets.etsmtl.ca:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: nginx-temp
+              mountPath: /var/cache/nginx
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: run-volume
+              mountPath: /var/run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+      volumes:
+        - name: nginx-temp
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: nginx-config
+        - name: run-volume
+          emptyDir: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: synapsets-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: synapsets

--- a/apps/clubs/synapsets/website/base/kustomization.yaml
+++ b/apps/clubs/synapsets/website/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml
+  - configMap.yaml

--- a/apps/clubs/synapsets/website/base/network.yaml
+++ b/apps/clubs/synapsets/website/base/network.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: synapsets-service
+spec:
+  ports:
+    - name: http
+      targetPort: 8080
+      protocol: TCP
+      port: 80
+  type: ClusterIP
+  selector:
+    app: synapsets

--- a/apps/clubs/synapsets/website/prod/ingress.yaml
+++ b/apps/clubs/synapsets/website/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: synapsets
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - synapsets.etsmtl.ca
+      secretName: synapsets-tls
+  rules:
+    - host: synapsets.etsmtl.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: synapsets-service
+                port:
+                  name: http

--- a/apps/clubs/synapsets/website/prod/ingress.yaml
+++ b/apps/clubs/synapsets/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: synapsets
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-http
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/synapsets/website/prod/kustomization.yaml
+++ b/apps/clubs/synapsets/website/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml

--- a/apps/clubs/synapsets/website/synapsets-shared.argoapp.yaml
+++ b/apps/clubs/synapsets/website/synapsets-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: synapsets
+  name: synapsets-shared
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"

--- a/apps/clubs/synapsets/website/synapsets.argoapp.yaml
+++ b/apps/clubs/synapsets/website/synapsets.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: synapsets
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: app=ghcr.io/clubcedille/synapsets.etsmtl.ca:latest
+    argocd-image-updater.argoproj.io/app.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: synapsets
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/synapsets/website/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true


### PR DESCRIPTION
Port du site web de Synapsets de k8s-cedille-production-v2 vers k8s-shared.

> Le wiki (WikiJS + postgres, données dans un PVC cephfs) n'est PAS migré pour l'instant. Résout #219 (partiel).