### PR TITLE
Calidum-Rotae: migrate service to k8s-shared

### DIFF
--- a/apps/clubs/calidum-rotae/base/calidum-rotae-service/deployment.yaml
+++ b/apps/clubs/calidum-rotae/base/calidum-rotae-service/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calidum-rotae
+  annotations:
+    kube-score/ignore: pod-networkpolicy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: calidum-rotae
+  template:
+    metadata:
+      labels:
+        app: calidum-rotae
+    spec:
+      containers:
+        - name: calidum-rotae
+          image: ghcr.io/clubcedille/calidum-rotae-service:2.0.1
+          imagePullPolicy: Always
+          env:
+            - name: CALIDUM_ROTAE_SERVICE_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: calidum-rotae-secrets
+                  key: CALIDUM_ROTAE_SERVICE_API_KEY
+            - name: OTEL_SERVICE_NAME
+              value: "calidum"
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: "http://coroot-coroot .coroot.svc.cluster.local:8080/v1/traces"
+            - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
+              value: "http://coroot-coroot .coroot.svc.cluster.local:8080/v1/logs"
+            - name: OTEL_EXPORTER_OTLP_PROTOCOL
+              value: "http/protobuf"
+            - name: OTEL_METRICS_EXPORTER
+              value: "none"
+            - name: OTEL_EXPORTER_OTLP_HEADERS
+              value: "x-api-key="
+          ports:
+            - containerPort: 3000
+          command:
+            ['/bin/sh', '-c', '/calidum_rotae_service --port 3000 --email_provider_hostname email-provider-service --email_provider_port 4000 --discord_provider_hostname discord-provider-service --discord_provider_port 5000 --shell_provider_hostname shell-provider-service --shell_provider_port 6000 --otel_otlp_exporter_host k8s-cedille-production-v2-coroot-ce-coroot.coroot.svc.cluster.local --otel_otlp_exporter_port 8080 --allowed_domains "http://localhost,http://localhost:3000,https://*.cedille.club,https://*.etsmtl.ca"']
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+            seccompProfile:
+              type: RuntimeDefault

--- a/apps/clubs/calidum-rotae/base/calidum-rotae-service/kustomization.yaml
+++ b/apps/clubs/calidum-rotae/base/calidum-rotae-service/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml

--- a/apps/clubs/calidum-rotae/base/calidum-rotae-service/network.yaml
+++ b/apps/clubs/calidum-rotae/base/calidum-rotae-service/network.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: calidum-rotae-service
+spec:
+  selector:
+    app: calidum-rotae
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/apps/clubs/calidum-rotae/base/discord-provider/deployment.yaml
+++ b/apps/clubs/calidum-rotae/base/discord-provider/deployment.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: discord-provider
+  annotations:
+    kube-score/ignore: pod-networkpolicy, pod-probes-identical
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: discord-provider
+  template:
+    metadata:
+      labels:
+        app: discord-provider
+    spec:
+      containers:
+        - name: discord-provider
+          image: ghcr.io/clubcedille/discord-provider:1.0.2
+          imagePullPolicy: Always
+          command:
+            ['/bin/sh', '-c', '/discord_provider --port 5000']
+          ports:
+            - containerPort: 5000
+          env:
+            - name: DISCORD_WEBHOOK_URL
+              valueFrom:
+                secretKeyRef:
+                  name: calidum-rotae-secrets
+                  key: DISCORD_WEBHOOK_URL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          livenessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 5000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - discord-provider
+              topologyKey: "kubernetes.io/hostname"
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: discord-provider-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: discord-provider

--- a/apps/clubs/calidum-rotae/base/discord-provider/kustomization.yaml
+++ b/apps/clubs/calidum-rotae/base/discord-provider/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml

--- a/apps/clubs/calidum-rotae/base/discord-provider/network.yaml
+++ b/apps/clubs/calidum-rotae/base/discord-provider/network.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: discord-provider-service
+spec:
+  selector:
+    app: discord-provider
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 5000
+      targetPort: 5000

--- a/apps/clubs/calidum-rotae/base/email-provider/configMap.yaml
+++ b/apps/clubs/calidum-rotae/base/email-provider/configMap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: email-provider-env
+  namespace: calidum-rotae
+data:
+  EMAIL_FROM_ADDRESS: email_from_address
+  EMAIL_FROM_NAME: email_from_name
+  EMAIL_NAME_TO: email_to_name
+  EMAIL_TO_ADDRESS: email_to_address
+  EMAIL_SUBJECT: email_subject

--- a/apps/clubs/calidum-rotae/base/email-provider/deployment.yaml
+++ b/apps/clubs/calidum-rotae/base/email-provider/deployment.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: email-provider
+  annotations:
+    kube-score/ignore: pod-networkpolicy, pod-probes
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: email-provider
+  template:
+    metadata:
+      labels:
+        app: email-provider
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - email-provider
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: email-provider
+          image: ghcr.io/clubcedille/email-provider:1.0.2
+          imagePullPolicy: Always
+          command:
+            ['/bin/sh', '-c', '/email_provider --port 4000']
+          ports:
+            - containerPort: 4000
+          envFrom:
+            - configMapRef:
+                name: email-provider-env
+          env:
+            - name: EMAIL_SMTP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: calidum-rotae-secrets
+                  key: EMAIL_SMTP_API_KEY
+            - name: EMAIL_FROM_ADDRESS
+              value: noreply@cedille.club
+            - name: EMAIL_FROM_NAME
+              value: cedille
+            - name: EMAIL_NAME_TO
+              value: cedille
+            - name: EMAIL_TO_ADDRESS
+              value: cedille@etsmtl.net
+            - name: EMAIL_SUBJECT
+              value: Submission
+          livenessProbe:
+            tcpSocket:
+              port: 4000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 4000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: email-provider-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: email-provider

--- a/apps/clubs/calidum-rotae/base/email-provider/kustomization.yaml
+++ b/apps/clubs/calidum-rotae/base/email-provider/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml
+  - configMap.yaml
+  - networkPolicy.yaml

--- a/apps/clubs/calidum-rotae/base/email-provider/network.yaml
+++ b/apps/clubs/calidum-rotae/base/email-provider/network.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: email-provider-service
+spec:
+  selector:
+    app: email-provider
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 4000
+      targetPort: 4000

--- a/apps/clubs/calidum-rotae/base/email-provider/networkPolicy.yaml
+++ b/apps/clubs/calidum-rotae/base/email-provider/networkPolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-email-provider-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: email-provider
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+      ports:
+        - protocol: UDP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/apps/clubs/calidum-rotae/base/shell-provider/deployment.yaml
+++ b/apps/clubs/calidum-rotae/base/shell-provider/deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shell-provider
+  annotations:
+    kube-score/ignore: pod-networkpolicy, pod-probes
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: shell-provider
+  template:
+    metadata:
+      labels:
+        app: shell-provider
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - shell-provider
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: shell-provider
+          image: ghcr.io/clubcedille/shell-provider:latest
+          imagePullPolicy: Always
+          command:
+            ['/bin/sh', '-c', '/shell_provider --port 6000']
+          ports:
+            - containerPort: 6000
+          livenessProbe:
+            tcpSocket:
+              port: 6000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 6000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: shell-provider-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: shell-provider

--- a/apps/clubs/calidum-rotae/base/shell-provider/kustomization.yaml
+++ b/apps/clubs/calidum-rotae/base/shell-provider/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml
+  - networkPolicy.yaml

--- a/apps/clubs/calidum-rotae/base/shell-provider/network.yaml
+++ b/apps/clubs/calidum-rotae/base/shell-provider/network.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: shell-provider-service
+spec:
+  selector:
+    app: shell-provider
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 6000
+      targetPort: 6000

--- a/apps/clubs/calidum-rotae/base/shell-provider/networkPolicy.yaml
+++ b/apps/clubs/calidum-rotae/base/shell-provider/networkPolicy.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-shell-provider-egress
+spec:
+  podSelector:
+    matchLabels:
+      app: shell-provider
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.10/32
+      ports:
+        - protocol: UDP
+          port: 53
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+      ports:
+        - protocol: TCP
+          port: 443

--- a/apps/clubs/calidum-rotae/calidum-rotae-shared.argoapp.yaml
+++ b/apps/clubs/calidum-rotae/calidum-rotae-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: calidum-rotae
+  name: calidum-rotae-shared
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"

--- a/apps/clubs/calidum-rotae/calidum-rotae.argoapp.yaml
+++ b/apps/clubs/calidum-rotae/calidum-rotae.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: calidum-rotae
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: calidum-rotae
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/calidum-rotae/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/calidum-rotae/prod/ingress.yaml
+++ b/apps/clubs/calidum-rotae/prod/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: calidum-rotae-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+    gatus.cedille/protocol: "tcp"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: calidum-rotae-service-tls
+      hosts:
+        - calidum-rotae.prodv2.cedille.club
+  rules:
+    - host: calidum-rotae.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: calidum-rotae-service
+                port:
+                  number: 3000

--- a/apps/clubs/calidum-rotae/prod/kustomization.yaml
+++ b/apps/clubs/calidum-rotae/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/discord-provider
+  - ../base/calidum-rotae-service
+  - ../base/email-provider
+  - ../base/shell-provider
+  - ingress.yaml


### PR DESCRIPTION
Port du service calidum-rotae (calidum-rotae-service + providers discord/email/shell) de k8s-cedille-production-v2 vers k8s-shared.

> Le secret `calidum-rotae-secrets` doit exister dans le namespace `calidum-rotae`. Résout #203.