### PR TITLE
Comets: migrate website to k8s-shared

### DIFF
--- a/apps/clubs/comets/website/base/configMap.yaml
+++ b/apps/clubs/comets/website/base/configMap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  custom-nginx.conf: |
+    server {
+      listen 8080;
+      server_name _;
+
+      root /usr/share/nginx/html;
+      index index.html;
+
+      location / {
+        try_files $uri $uri/ /index.html;
+      }
+    }

--- a/apps/clubs/comets/website/base/deployment.yaml
+++ b/apps/clubs/comets/website/base/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: comets-web
+  annotations:
+    kube-score/ignore: container-image-pull-policy,container-image-tag, pod-networkpolicy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: comets-web
+  template:
+    metadata:
+      labels:
+        app: comets-web
+    spec:
+      containers:
+        - name: comets-web
+          image: ghcr.io/clubcedille/comets-web:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: nginx-temp
+              mountPath: /var/cache/nginx
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: run-volume
+              mountPath: /var/run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+      volumes:
+        - name: nginx-temp
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: nginx-config
+        - name: run-volume
+          emptyDir: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: comets-web-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: comets-web

--- a/apps/clubs/comets/website/base/kustomization.yaml
+++ b/apps/clubs/comets/website/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configMap.yaml

--- a/apps/clubs/comets/website/base/service.yaml
+++ b/apps/clubs/comets/website/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: comets-web-service
+spec:
+  ports:
+    - name: http
+      targetPort: 8080
+      protocol: TCP
+      port: 80
+  type: ClusterIP
+  selector:
+    app: comets-web

--- a/apps/clubs/comets/website/comets-web-shared.argoapp.yaml
+++ b/apps/clubs/comets/website/comets-web-shared.argoapp.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: comets-web
+  name: comets-web-shared
   namespace: argocd
   annotations:
     argocd.argoproj.io/sync-wave: "2"

--- a/apps/clubs/comets/website/comets.argoapp.yaml
+++ b/apps/clubs/comets/website/comets.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: comets-web
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: webapp=ghcr.io/clubcedille/comets-web:latest
+    argocd-image-updater.argoproj.io/webapp.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: comets
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/comets/website/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/comets/website/prod/ingress.yaml
+++ b/apps/clubs/comets/website/prod/ingress.yaml
@@ -1,0 +1,51 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: comets-web-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - comets.prodv2.cedille.club
+      secretName: cedille-cert-tls
+  rules:
+    - host: comets.prodv2.cedille.club
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: comets-web-service
+                port:
+                  name: http
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: comets-web-ingress-prod
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - comets-ets.com
+      secretName: cedille-cert-tls-prod
+  rules:
+    - host: comets-ets.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: comets-web-service
+                port:
+                  name: http

--- a/apps/clubs/comets/website/prod/ingress.yaml
+++ b/apps/clubs/comets/website/prod/ingress.yaml
@@ -29,7 +29,7 @@ kind: Ingress
 metadata:
   name: comets-web-ingress-prod
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-http
+    cert-manager.io/cluster-issuer: letsencrypt-prod
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/comets/website/prod/kustomization.yaml
+++ b/apps/clubs/comets/website/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml


### PR DESCRIPTION
Port du site web Comets (NextJS) de k8s-cedille-production-v2 vers k8s-shared. Résout #231.