### PR TITLE
fix(nextcloud-new): increase startupProbe budget for slow first-boot rsync

### DIFF
--- a/apps/nextcloud-new/helm/nextcloud-values.yaml
+++ b/apps/nextcloud-new/helm/nextcloud-values.yaml
@@ -312,7 +312,13 @@ startupProbe:
   initialDelaySeconds: 60
   periodSeconds: 10
   timeoutSeconds: 5
-  failureThreshold: 30
+  # Generous budget (~40min) for the one-time first-boot rsync of Nextcloud's app code onto
+  # the CephFS-backed config PVC, which has been observed taking 10-25+ minutes on this
+  # cluster. Without this, the container gets SIGKILLed by the probe before install finishes,
+  # then restarts and repeats the slow rsync from scratch — an unrecoverable crash-loop.
+  # Subsequent boots skip the rsync (version.php already matches) so this doesn't slow down
+  # normal restarts.
+  failureThreshold: 240
   successThreshold: 1
 hpa:
   enabled: false


### PR DESCRIPTION
## Summary
- Found the real root cause of the nextcloud-new crash-loop (persisted even after scaling to a single replica): `startupProbe.failureThreshold: 30` at `periodSeconds: 10` only gives ~6 minutes before the probe fails and kubelet SIGKILLs the container.
- The image's entrypoint does a one-time rsync of the full Nextcloud app tree onto the CephFS-backed config PVC on first boot, observed taking 10-25+ minutes on this cluster's CephFS.
- Every ~6 minutes the container got killed mid-rsync, restarted, and repeated the slow copy from scratch — an unrecoverable loop, unrelated to the earlier multi-replica race (that was a red herring, though also worth avoiding — see #353).
- Bumped `failureThreshold` to 240 (~40 min budget). Subsequent restarts are unaffected since the rsync is skipped once `version.php` matches.

## Test plan
- [ ] Single replica (per #353) completes install without being killed
- [ ] `installed: true` confirmed via `status.php`
- [ ] Follow-up PR reverts replicaCount to 3