### PR TITLE
fix(nextcloud-new): revert to 3 replicas now that install is confirmed

### DIFF
--- a/apps/nextcloud-new/helm/nextcloud-values.yaml
+++ b/apps/nextcloud-new/helm/nextcloud-values.yaml
@@ -11,11 +11,7 @@ image:
   pullSecrets:
     - dockerhub-pull
 # Number of replicas to be deployed
-# TEMPORARY: pinned to 1 during initial install — the docker image's entrypoint uses a
-# flock-based lock on the shared RWX PVC to serialize concurrent first-boot installs across
-# replicas, but on a fresh CephFS-backed PVC this repeatedly crash-looped instead of
-# converging. Revert to 3 once `occ status` confirms installed:true.
-replicaCount: 1
+replicaCount: 3
 ## Allowing use of ingress controllers
 ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ##


### PR DESCRIPTION
## Summary
- Follow-up to #353 / #364: install is now confirmed complete (`status.php` returns `installed:true`).
- Reverts the temporary `replicaCount: 1` back to the intended `3`.

## Test plan
- [ ] All 3 replicas become Ready without crash-looping after sync
- [ ] OIDC login + upload/download smoke test