### PR TITLE
fix: use letsencrypt-http for non-Cloudflare hosted domains

### DIFF
--- a/apps/clubs/cedille/website/prod/ingress.yaml
+++ b/apps/clubs/cedille/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: cedille
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/comets/website/prod/ingress.yaml
+++ b/apps/clubs/comets/website/prod/ingress.yaml
@@ -29,7 +29,7 @@ kind: Ingress
 metadata:
   name: comets-web-ingress-prod
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/conjure/website/prod/ingress.yaml
+++ b/apps/clubs/conjure/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: conjure-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/dronolab/website/prod/ingress.yaml
+++ b/apps/clubs/dronolab/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: dronolab-webapp-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/ingenieuses/website/prod/ingress.yaml
+++ b/apps/clubs/ingenieuses/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: ingenieuses
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/integrale/website/prod/ingress.yaml
+++ b/apps/clubs/integrale/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: integrale-website-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/saveursdegenie/website/prod/ingress.yaml
+++ b/apps/clubs/saveursdegenie/website/prod/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: saveursdegenie
   namespace: saveursdegenie
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/synapsets/website/prod/ingress.yaml
+++ b/apps/clubs/synapsets/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: synapsets
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:


### PR DESCRIPTION
The migrated sites use `letsencrypt-prod` (Cloudflare DNS01), but domains like `*.etsmtl.ca`, `ingenieuses.ca` and `comets-ets.com` are not hosted in the club's Cloudflare zones, so the ACME DNS01 challenge fails (`Found no Zones for domain`).

Switch those ingresses to `letsencrypt-http` (HTTP01 via contour), matching the previous prodv2 setup. Domains in `cedille.club`/`prodv2.cedille.club` keep `letsencrypt-prod`.