### PR TITLE
feat(grav): migrate crabeweb, raconteurs, grav-smoke-test to k8s-shared

### DIFF
--- a/apps/clubs/cedille/website/prod/ingress.yaml
+++ b/apps/clubs/cedille/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: cedille
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/comets/website/prod/ingress.yaml
+++ b/apps/clubs/comets/website/prod/ingress.yaml
@@ -29,7 +29,7 @@ kind: Ingress
 metadata:
   name: comets-web-ingress-prod
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/conjure/website/prod/ingress.yaml
+++ b/apps/clubs/conjure/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: conjure-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/crabeweb/grav/crabeweb-grav.argoapp.yaml
+++ b/apps/clubs/crabeweb/grav/crabeweb-grav.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: crabeweb-grav
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/clubcedille/grav:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: crabeweb-grav
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/crabeweb/grav/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/crabeweb/grav/prod/kustomization.yaml
+++ b/apps/clubs/crabeweb/grav/prod/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: crabeweb-
+
+resources:
+  - ../../../../../bases/grav
+
+patches:
+  - path: vault-patch.yaml
+  - target:
+      kind: HTTPProxy
+      name: grav-ingress
+    patch: |-
+      - op: replace
+        path: /spec/virtualhost/fqdn
+        value: crabe.etsmtl.ca
+      - op: replace
+        path: /spec/virtualhost/tls/secretName
+        value: crabeweb-grav-tls
+      - op: replace
+        path: /spec/routes/0/services/0/name
+        value: crabeweb-grav
+  - target:
+      kind: Certificate
+      name: grav-tls
+    patch: |-
+      - op: replace
+        path: /spec/secretName
+        value: crabeweb-grav-tls
+      - op: replace
+        path: /spec/commonName
+        value: crabe.etsmtl.ca
+      - op: replace
+        path: /spec/dnsNames/0
+        value: crabe.etsmtl.ca
+      - op: replace
+        path: /spec/issuerRef/name
+        value: letsencrypt-http
+  - target:
+      kind: RandomSecret
+    patch: |-
+      - op: replace
+        path: /spec/path
+        value: kv/data/crabeweb-grav/default/grav

--- a/apps/clubs/crabeweb/grav/prod/vault-patch.yaml
+++ b/apps/clubs/crabeweb/grav/prod/vault-patch.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grav
+spec:
+  template:
+    metadata:
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "secret-reader"
+        vault.hashicorp.com/agent-inject-template-gitsync: |
+          {{- with secret "github/token/crabeweb-grav" -}}
+          enabled: true
+          folders:
+            - pages
+            - plugins
+            - themes
+            - config
+          SyncNotice: null
+          sync:
+            on_save: true
+            on_delete: true
+            on_media: true
+            cron_enable: true
+            cron_at: '*/10 * * * *'
+          local_repository: null
+          repository: 'https://github.com/ClubCedille/crabe.demo.prodv2.cedille.club.git'
+          no_user: '0'
+          user: x-access-token
+          password: "{{ .Data.token }}"
+          webhook_enabled: '1'
+          webhook: '/_git_webhook'
+          branch: main
+          remote:
+            name: origin
+            branch: main
+          git:
+            author: gitsync
+            message: '(Grav GitSync) Automatic Commit'
+            name: GitSync
+            email: git-sync@trilby.media
+            bin: git
+            ignore: null
+            private_key: null
+          logging: true
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-admin_pwd: |
+          {{- with secret "kv/data/crabeweb-grav/default/grav/crabeweb-grav-init-pwd" -}}
+          state: enabled
+          email: admin@crabe.etsmtl.ca
+          username: admin
+          fullname: admin
+          title: Administrator
+          access:
+            admin:
+              login: true
+              super: true
+            site:
+              login: true
+          password: "{{ .Data.data.password }}"
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-sre_pwd: |
+          {{- with secret "kv/data/crabeweb-grav/default/grav/crabeweb-grav-sre-pwd" -}}
+          state: enabled
+          email: sre@cedille.club
+          username: sre
+          fullname: SRE
+          title: SRE
+          access:
+            admin:
+              login: true
+              super: true
+            site:
+              login: true
+          password: "{{ .Data.data.password }}"
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-salt: |
+          {{- with secret "kv/data/crabeweb-grav/default/grav/crabeweb-grav-salt" -}}
+          salt: "{{ .Data.data.salt }}"
+          {{- end }}

--- a/apps/clubs/dronolab/website/prod/ingress.yaml
+++ b/apps/clubs/dronolab/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: dronolab-webapp-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/grav-smoke-test/grav/grav-smoke-test-grav.argoapp.yaml
+++ b/apps/clubs/grav-smoke-test/grav/grav-smoke-test-grav.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: grav-smoke-test-grav
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/clubcedille/grav:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: grav-smoke-test-grav
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/grav-smoke-test/grav/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/grav-smoke-test/grav/prod/kustomization.yaml
+++ b/apps/clubs/grav-smoke-test/grav/prod/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: grav-smoke-test-
+
+resources:
+  - ../../../../../bases/grav
+
+patches:
+  - path: vault-patch.yaml
+  - target:
+      kind: HTTPProxy
+      name: grav-ingress
+    patch: |-
+      - op: replace
+        path: /spec/virtualhost/fqdn
+        value: grav-smoke-test.prodv2.cedille.club
+      - op: replace
+        path: /spec/virtualhost/tls/secretName
+        value: grav-smoke-test-grav-tls
+      - op: replace
+        path: /spec/routes/0/services/0/name
+        value: grav-smoke-test-grav
+  - target:
+      kind: Certificate
+      name: grav-tls
+    patch: |-
+      - op: replace
+        path: /spec/secretName
+        value: grav-smoke-test-grav-tls
+      - op: replace
+        path: /spec/commonName
+        value: grav-smoke-test.prodv2.cedille.club
+      - op: replace
+        path: /spec/dnsNames/0
+        value: grav-smoke-test.prodv2.cedille.club
+      - op: replace
+        path: /spec/issuerRef/name
+        value: letsencrypt-http
+  - target:
+      kind: RandomSecret
+    patch: |-
+      - op: replace
+        path: /spec/path
+        value: kv/data/grav-smoke-test-grav/default/grav

--- a/apps/clubs/grav-smoke-test/grav/prod/vault-patch.yaml
+++ b/apps/clubs/grav-smoke-test/grav/prod/vault-patch.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grav
+spec:
+  template:
+    metadata:
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "secret-reader"
+        vault.hashicorp.com/agent-inject-template-gitsync: |
+          {{- with secret "github/token/grav-smoke-test-grav" -}}
+          enabled: true
+          folders:
+            - pages
+            - plugins
+            - themes
+            - config
+          SyncNotice: null
+          sync:
+            on_save: true
+            on_delete: true
+            on_media: true
+            cron_enable: true
+            cron_at: '*/10 * * * *'
+          local_repository: null
+          repository: 'https://github.com/ClubCedille/grav-smoke-test.prodv2.cedille.club.git'
+          no_user: '0'
+          user: x-access-token
+          password: "{{ .Data.token }}"
+          webhook_enabled: '1'
+          webhook: '/_git_webhook'
+          branch: main
+          remote:
+            name: origin
+            branch: main
+          git:
+            author: gitsync
+            message: '(Grav GitSync) Automatic Commit'
+            name: GitSync
+            email: git-sync@trilby.media
+            bin: git
+            ignore: null
+            private_key: null
+          logging: true
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-admin_pwd: |
+          {{- with secret "kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-init-pwd" -}}
+          state: enabled
+          email: admin@grav-smoke-test.prodv2.cedille.club
+          username: admin
+          fullname: admin
+          title: Administrator
+          access:
+            admin:
+              login: true
+              super: true
+            site:
+              login: true
+          password: "{{ .Data.data.password }}"
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-sre_pwd: |
+          {{- with secret "kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-sre-pwd" -}}
+          state: enabled
+          email: sre@cedille.club
+          username: sre
+          fullname: SRE
+          title: SRE
+          access:
+            admin:
+              login: true
+              super: true
+            site:
+              login: true
+          password: "{{ .Data.data.password }}"
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-salt: |
+          {{- with secret "kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-salt" -}}
+          salt: "{{ .Data.data.salt }}"
+          {{- end }}

--- a/apps/clubs/ingenieuses/website/prod/ingress.yaml
+++ b/apps/clubs/ingenieuses/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: ingenieuses
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/integrale/website/prod/ingress.yaml
+++ b/apps/clubs/integrale/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: integrale-website-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/raconteurs/grav/prod/kustomization.yaml
+++ b/apps/clubs/raconteurs/grav/prod/kustomization.yaml
@@ -1,0 +1,45 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namePrefix: raconteurs-
+
+resources:
+  - ../../../../../bases/grav
+
+patches:
+  - path: vault-patch.yaml
+  - target:
+      kind: HTTPProxy
+      name: grav-ingress
+    patch: |-
+      - op: replace
+        path: /spec/virtualhost/fqdn
+        value: raconteurs.etsmtl.ca
+      - op: replace
+        path: /spec/virtualhost/tls/secretName
+        value: raconteurs-grav-tls
+      - op: replace
+        path: /spec/routes/0/services/0/name
+        value: raconteurs-grav
+  - target:
+      kind: Certificate
+      name: grav-tls
+    patch: |-
+      - op: replace
+        path: /spec/secretName
+        value: raconteurs-grav-tls
+      - op: replace
+        path: /spec/commonName
+        value: raconteurs.etsmtl.ca
+      - op: replace
+        path: /spec/dnsNames/0
+        value: raconteurs.etsmtl.ca
+      - op: replace
+        path: /spec/issuerRef/name
+        value: letsencrypt-http
+  - target:
+      kind: RandomSecret
+    patch: |-
+      - op: replace
+        path: /spec/path
+        value: kv/data/raconteurs-grav/default/grav

--- a/apps/clubs/raconteurs/grav/prod/vault-patch.yaml
+++ b/apps/clubs/raconteurs/grav/prod/vault-patch.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grav
+spec:
+  template:
+    metadata:
+      annotations:
+        vault.hashicorp.com/agent-inject: "true"
+        vault.hashicorp.com/role: "secret-reader"
+        vault.hashicorp.com/agent-inject-template-gitsync: |
+          {{- with secret "github/token/raconteurs-grav" -}}
+          enabled: true
+          folders:
+            - pages
+            - plugins
+            - themes
+            - config
+          SyncNotice: null
+          sync:
+            on_save: true
+            on_delete: true
+            on_media: true
+            cron_enable: true
+            cron_at: '*/10 * * * *'
+          local_repository: null
+          repository: 'https://github.com/ClubCedille/raconteurs.etsmtl.ca.git'
+          no_user: '0'
+          user: x-access-token
+          password: "{{ .Data.token }}"
+          webhook_enabled: '1'
+          webhook: '/_git_webhook'
+          branch: main
+          remote:
+            name: origin
+            branch: main
+          git:
+            author: gitsync
+            message: '(Grav GitSync) Automatic Commit'
+            name: GitSync
+            email: git-sync@trilby.media
+            bin: git
+            ignore: null
+            private_key: null
+          logging: true
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-admin_pwd: |
+          {{- with secret "kv/data/raconteurs-grav/default/grav/raconteurs-grav-init-pwd" -}}
+          state: enabled
+          email: admin@raconteurs.etsmtl.ca
+          username: admin
+          fullname: admin
+          title: Administrator
+          access:
+            admin:
+              login: true
+              super: true
+            site:
+              login: true
+          password: "{{ .Data.data.password }}"
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-sre_pwd: |
+          {{- with secret "kv/data/raconteurs-grav/default/grav/raconteurs-grav-sre-pwd" -}}
+          state: enabled
+          email: sre@cedille.club
+          username: sre
+          fullname: SRE
+          title: SRE
+          access:
+            admin:
+              login: true
+              super: true
+            site:
+              login: true
+          password: "{{ .Data.data.password }}"
+          {{- end }}
+        vault.hashicorp.com/agent-inject-template-salt: |
+          {{- with secret "kv/data/raconteurs-grav/default/grav/raconteurs-grav-salt" -}}
+          salt: "{{ .Data.data.salt }}"
+          {{- end }}

--- a/apps/clubs/raconteurs/grav/raconteurs-grav.argoapp.yaml
+++ b/apps/clubs/raconteurs/grav/raconteurs-grav.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: raconteurs-grav
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/clubcedille/grav:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: raconteurs-grav
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/raconteurs/grav/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/saveursdegenie/website/prod/ingress.yaml
+++ b/apps/clubs/saveursdegenie/website/prod/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: saveursdegenie
   namespace: saveursdegenie
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/synapsets/website/prod/ingress.yaml
+++ b/apps/clubs/synapsets/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: synapsets
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/vault-gh-roles/crabeweb-grav.yaml
+++ b/apps/vault-gh-roles/crabeweb-grav.yaml
@@ -1,0 +1,12 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GitHubSecretEngineRole
+metadata:
+  name: crabeweb-grav
+spec:
+  authentication:
+    path: kubernetes
+    role: config-admin
+  path: github
+  repositories:
+    - crabe.demo.prodv2.cedille.club
+  organizationName: ClubCedille

--- a/apps/vault-gh-roles/grav-smoke-test-grav.yaml
+++ b/apps/vault-gh-roles/grav-smoke-test-grav.yaml
@@ -1,0 +1,12 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GitHubSecretEngineRole
+metadata:
+  name: grav-smoke-test-grav
+spec:
+  authentication:
+    path: kubernetes
+    role: config-admin
+  path: github
+  repositories:
+    - grav-smoke-test.prodv2.cedille.club
+  organizationName: ClubCedille

--- a/apps/vault-gh-roles/kustomization.yaml
+++ b/apps/vault-gh-roles/kustomization.yaml
@@ -3,4 +3,7 @@ kind: Kustomization
 
 namespace: vault
 
-resources: []
+resources:
+  - crabeweb-grav.yaml
+  - raconteurs-grav.yaml
+  - grav-smoke-test-grav.yaml

--- a/apps/vault-gh-roles/raconteurs-grav.yaml
+++ b/apps/vault-gh-roles/raconteurs-grav.yaml
@@ -1,0 +1,12 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: GitHubSecretEngineRole
+metadata:
+  name: raconteurs-grav
+spec:
+  authentication:
+    path: kubernetes
+    role: config-admin
+  path: github
+  repositories:
+    - raconteurs.etsmtl.ca
+  organizationName: ClubCedille


### PR DESCRIPTION
## Grav sites migration

Single PR for the three Grav CMS sites, rendered from `bases/grav` Jinja2 templates (the `request-grav.yml` pattern ported in #346).

| Site | Domain | Namespace | Path |
|---|---|---|---|
| crabeweb-grav | crabe.etsmtl.ca | crabeweb-grav | `apps/clubs/crabeweb/grav` |
| raconteurs-grav | raconteurs.etsmtl.ca | raconteurs-grav | `apps/clubs/raconteurs/grav` |
| grav-smoke-test-grav | grav-smoke-test.prodv2.cedille.club | grav-smoke-test-grav | `apps/clubs/grav-smoke-test/grav` |

Résout #224, #226.

### Included
- 3 ArgoCD Applications (`*-grav.argoapp.yaml`, project `k8s-shared`)
- `prod/{kustomization,vault-patch}.yaml` per site (Vault agent-inject for gitsync/admin/sre/salt)
- Vault `GitHubSecretEngineRole` for each site + `apps/vault-gh-roles/kustomization.yaml` update
- Certificates via `letsencrypt-http`

### Not included (manual, like the static-site migrations)
- cephfs PVC data is recreated fresh; `grav-accounts-pvc`/`grav-data-pvc` metadata (user accounts, data) is NOT copied over — flag if account/data migration is needed
- DNS repoint in Cloudflare to the new cluster IP
- GitHub repos assumed already in place: `crabe.demo.prodv2.cedille.club`, `raconteurs.etsmtl.ca`, `grav-smoke-test.prodv2.cedille.club`

### Prerequisites to verify before merge/applying
- `crabeweb-grav`, `raconteurs-grav`, `grav-smoke-test-grav` secrets must exist in Vault (RandomSecret writes to `kv/data/<ns>/default/grav`)