### PR TITLE
feat(wiki): migrate capra, sonia and synapsets wikijs sites to k8s-shared

### DIFF
--- a/apps/clubs/capra/wiki/base/kustomization.yaml
+++ b/apps/clubs/capra/wiki/base/kustomization.yaml
@@ -87,8 +87,6 @@ patches:
       spec:
         template:
           spec:
-            nodeSelector:
-              kubernetes.io/hostname: k8s-cedille-production-v2-worker-4
             securityContext: {}
             containers:
               - name: wiki-postgresql

--- a/apps/clubs/capra/wiki/base/kustomization.yaml
+++ b/apps/clubs/capra/wiki/base/kustomization.yaml
@@ -1,0 +1,117 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - name: wiki
+    releaseName: wiki
+    version: 2.2.17
+    repo: https://charts.js.wiki
+    valuesInline:
+      image:
+        tag: "2.5"
+        imagePullPolicy: Always
+      ingress:
+        enabled: false
+      resources:
+        limits:
+          cpu: 400m
+          memory: 512Mi
+          ephemeral-storage: 1Gi
+        requests:
+          cpu: 200m
+          memory: 256Mi
+          ephemeral-storage: 256Mi
+      readinessProbe:
+        httpGet:
+          path: /
+          port: http
+      postgresql:
+        enabled: true
+        image:
+          registry: docker.io
+          repository: bitnamilegacy/postgresql
+          tag: "11"
+          pullPolicy: Always
+        existingSecret: wikijs-postgres-secret
+        securityContext:
+          enabled: false
+        livenessProbe:
+          initialDelaySeconds: 3600
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 6
+        readinessProbe:
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 60
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+            ephemeral-storage: 1Gi
+          requests:
+            cpu: 250m
+            memory: 256Mi
+            ephemeral-storage: 256Mi
+        volumePermissions:
+          enabled: false
+        persistence:
+          enabled: true
+          size: 10Gi
+          storageClass: cephfs
+      startupProbe:
+        initialDelaySeconds: 120
+patches:
+  - target:
+      kind: Deployment
+      name: wiki
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: wiki
+        annotations:
+          kube-score/ignore: pod-networkpolicy, container-security-context-privileged, container-security-context-user-group-id, container-security-context-readonlyrootfilesystem
+  - target:
+      kind: StatefulSet
+      name: wiki-postgresql
+    patch: |-
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: wiki-postgresql
+        annotations:
+          argocd.argoproj.io/sync-options: Replace=true
+          kube-score/ignore: pod-networkpolicy, container-security-context-privileged, container-security-context-user-group-id, container-security-context-readonlyrootfilesystem
+      spec:
+        template:
+          spec:
+            nodeSelector:
+              kubernetes.io/hostname: k8s-cedille-production-v2-worker-4
+            securityContext: {}
+            containers:
+              - name: wiki-postgresql
+                securityContext: {}
+  - target:
+      kind: Pod
+      name: wiki-test-connection
+    patch: |-
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: wiki-test-connection
+        annotations:
+          kube-score/ignore: pod-networkpolicy, container-image-tag, container-resources, container-ephemeral-storage-request-and-limit, container-security-context-privileged, container-security-context-user-group-id, container-security-context-readonlyrootfilesystem
+      spec:
+        containers:
+        - name: wget
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - wget -q --spider wiki:80
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5

--- a/apps/clubs/capra/wiki/capra-wikijs.argoapp.yaml
+++ b/apps/clubs/capra/wiki/capra-wikijs.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: capra-wikijs
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: capra-wikijs
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/capra/wiki/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/capra/wiki/prod/ingress.yaml
+++ b/apps/clubs/capra/wiki/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wikijs-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: capra-wikijs-tls
+      hosts:
+        - wiki.capra.etsmtl.ca
+  rules:
+    - host: wiki.capra.etsmtl.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: wiki
+                port:
+                  name: http

--- a/apps/clubs/capra/wiki/prod/kustomization.yaml
+++ b/apps/clubs/capra/wiki/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml

--- a/apps/clubs/sonia/wiki/base/kustomization.yaml
+++ b/apps/clubs/sonia/wiki/base/kustomization.yaml
@@ -1,0 +1,33 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - name: wiki
+    releaseName: wiki
+    version: 2.2.17
+    repo: https://charts.js.wiki
+    valuesInline:
+      image.tag: 2.5
+      image.pullPolicy: Always
+      resources.limits:
+        cpu: 200m
+        memory: 256Mi
+      ingress.enabled: false
+      # externalPostgresql:
+      #   databaseURL: postgresql://postgres:postgres@cnpg-rw.sonia-wikijs.svc.cluster.local:5432/wiki
+      postgresql:
+        enabled: true #false
+        image:
+          registry: public.ecr.aws
+          repository: bitnami/postgresql
+          tag: 11.21.0-debian-11-r52
+        # postgresql-uri: cnpg-rw.sonia-wikijs.svc.cluster.local
+        postgresqlDatabase: wiki
+        postgresqlUser: postgres
+        existingSecret: wikijs-postgres-secret
+        persistence:
+          enabled: true
+          size: 10Gi
+          storageClass: cephfs
+      startupProbe:
+        initialDelaySeconds: 10

--- a/apps/clubs/sonia/wiki/base/kustomization.yaml
+++ b/apps/clubs/sonia/wiki/base/kustomization.yaml
@@ -18,9 +18,9 @@ helmCharts:
       postgresql:
         enabled: true #false
         image:
-          registry: public.ecr.aws
-          repository: bitnami/postgresql
-          tag: 11.21.0-debian-11-r52
+          registry: docker.io
+          repository: bitnamilegacy/postgresql
+          tag: "11"
         # postgresql-uri: cnpg-rw.sonia-wikijs.svc.cluster.local
         postgresqlDatabase: wiki
         postgresqlUser: postgres

--- a/apps/clubs/sonia/wiki/prod/ingress.yaml
+++ b/apps/clubs/sonia/wiki/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wikijs
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: wikijs-cert-tls
+      hosts:
+        - wiki.sonia.etsmtl.ca
+  rules:
+    - host: wiki.sonia.etsmtl.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: wiki
+                port:
+                  name: http

--- a/apps/clubs/sonia/wiki/prod/kustomization.yaml
+++ b/apps/clubs/sonia/wiki/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml

--- a/apps/clubs/sonia/wiki/sonia-wikijs.argoapp.yaml
+++ b/apps/clubs/sonia/wiki/sonia-wikijs.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: sonia-wikijs
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: sonia-wikijs
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/sonia/wiki/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/synapsets/wiki/base/kustomization.yaml
+++ b/apps/clubs/synapsets/wiki/base/kustomization.yaml
@@ -1,0 +1,41 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+helmCharts:
+  - name: wiki
+    releaseName: wiki
+    version: 2.2.17
+    repo: https://charts.js.wiki
+    valuesInline:
+      securityContext:
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 10001
+      allowPrivilegeEscalation: false
+      image.tag: 2.5
+      image.pullPolicy: Always
+      resources:
+        limits:
+          cpu: 250m
+          memory: 512Mi
+          ephemeral-storage: 1024Mi
+        requests:
+          cpu: 200m
+          memory: 256Mi
+          ephemeral-storage: 512Mi
+      ingress.enabled: false
+      postgresql:
+        enabled: true
+        image:
+          registry: public.ecr.aws
+          repository: bitnami/postgresql
+          tag: 11.21.0-debian-11-r52
+        postgresqlDatabase: wiki
+        postgresqlUser: postgres
+        existingSecret: wikijs-postgres-secret
+        persistence:
+          enabled: true
+          size: 10Gi
+          storageClass: cephfs
+      startupProbe:
+        initialDelaySeconds: 10

--- a/apps/clubs/synapsets/wiki/base/kustomization.yaml
+++ b/apps/clubs/synapsets/wiki/base/kustomization.yaml
@@ -27,9 +27,9 @@ helmCharts:
       postgresql:
         enabled: true
         image:
-          registry: public.ecr.aws
-          repository: bitnami/postgresql
-          tag: 11.21.0-debian-11-r52
+          registry: docker.io
+          repository: bitnamilegacy/postgresql
+          tag: "11"
         postgresqlDatabase: wiki
         postgresqlUser: postgres
         existingSecret: wikijs-postgres-secret

--- a/apps/clubs/synapsets/wiki/prod/ingress.yaml
+++ b/apps/clubs/synapsets/wiki/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wikijs
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: wikijs-cert-tls
+      hosts:
+        - wiki.synapsets.prodv2.cedille.club
+  rules:
+    - host: wiki.synapsets.prodv2.cedille.club
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: wiki
+                port:
+                  name: http

--- a/apps/clubs/synapsets/wiki/prod/kustomization.yaml
+++ b/apps/clubs/synapsets/wiki/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml

--- a/apps/clubs/synapsets/wiki/synapsets-wikijs.argoapp.yaml
+++ b/apps/clubs/synapsets/wiki/synapsets-wikijs.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: synapsets-wikijs
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: synapsets-wikijs
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/synapsets/wiki/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true


### PR DESCRIPTION
Migrates the three WikiJS sites from k8s-cedille-production-v2 to k8s-shared (namespaces capra-wikijs, sonia-wikijs, synapsets-wikijs), manifests copied verbatim.

- capra: wiki.capra.etsmtl.ca (letsencrypt-http)
- sonia: wiki.sonia.etsmtl.ca (letsencrypt-http)
- synapsets: wiki.synapsets.prodv2.cedille.club (letsencrypt-http)
- helm chart wiki 2.2.17 (https://charts.js.wiki), bundled bitnami postgres on cephfs 10Gi
- DB secret (wikijs-postgres-secret) is a live secret on prodv2; it travels with the velero namespace restore
- Note: sonia base kept as-is; the orphaned postgresql.yaml/migration.yaml CNPG files are not deployed (bundled postgres is authoritative), so they were not copied

Closes #204 #219 #225