### PR TITLE
feat(migration): migrate remaining apps (wordpress, forom, trema, markets, patchets, penpot, planifets, data-acq) to k8s-shared

### DIFF
--- a/apps/clubs/applets/planifets-chatbot/README.md
+++ b/apps/clubs/applets/planifets-chatbot/README.md
@@ -1,0 +1,75 @@
+# planifets-chatbot
+
+Applet GitOps pour le composant `planifets-chatbot` déployé sur le cluster `k8s-cedille-production-v2` via ArgoCD.
+
+Ce dossier ne contient plus une stack frontend/backend complète : il gère uniquement le service **Qdrant** utilisé par le chatbot, avec les secrets associés par environnement.
+
+## Ce qui est déployé
+
+| Composant | Image | Port | Rôle |
+|-----------|-------|------|------|
+| Qdrant | `qdrant/qdrant@sha256:...` | `6333` / `6334` | Base vectorielle du chatbot |
+
+## Environnements
+
+| Env | Namespace | ArgoCD Application | Secret Vault |
+|-----|-----------|--------------------|--------------|
+| dev | `planifets-dev` | `planifets-chatbot-dev` | `kv/data/planifets-dev/default/chatbot/qdrant` |
+| staging | `planifets-staging` | `planifets-chatbot-staging` | `kv/data/planifets-staging/default/chatbot/qdrant` |
+| prod | `planifets` | `planifets-chatbot` | `kv/data/planifets/default/planifets/planifets-backend` |
+
+## Structure actuelle
+
+```text
+apps/applets/planifets-chatbot/
+├── planifets-chatbot.argoapp.yaml   # 3 Applications ArgoCD : dev, staging, prod
+├── base/
+│   └── qdrant/
+│       ├── service.yaml             # Service ClusterIP (6333/6334)
+│       └── statefulset.yaml         # StatefulSet Qdrant + PVC
+├── dev/
+│   ├── kustomization.yaml           # Base qdrant + secret Vault dev
+│   └── vault-secret.yaml
+├── staging/
+│   ├── kustomization.yaml           # Base qdrant + secret Vault staging
+│   └── vault-secret.yaml
+└── prod/
+    ├── kustomization.yaml           # Base qdrant + secret Vault prod
+    └── vault-secret.yaml
+```
+
+## Secrets Vault
+
+Les secrets sont gérés via **HashiCorp Vault** et l'opérateur `vault-secret`.
+
+Chaque environnement crée un secret Kubernetes `planifets-chatbot-secret` contenant la clé `qdrant_api_key`, lue par le StatefulSet via `QDRANT__SERVICE__API_KEY`.
+
+### Chemins Vault attendus
+
+- `dev` → `kv/data/planifets-dev/default/chatbot/qdrant`
+- `staging` → `kv/data/planifets-staging/default/chatbot/qdrant`
+- `prod` → `kv/data/planifets/default/planifets/planifets-backend`
+
+## Déploiement
+
+1. Créer ou mettre à jour la valeur `api_key` pour `dev`/`staging`, ou `qdrant_api_key` pour `prod`, dans le chemin Vault de l'environnement visé.
+2. Laisser ArgoCD synchroniser l'application correspondante.
+3. Vérifier que le secret `planifets-chatbot-secret` et le StatefulSet Qdrant sont bien présents dans le namespace.
+
+### Vérifications utiles
+
+```bash
+kubectl get pods -n planifets-dev
+kubectl get pods -n planifets-staging
+kubectl get pods -n planifets
+
+kubectl get secret -n planifets-dev planifets-chatbot-secret
+kubectl get statefulset -n planifets-dev planifets-chatbot-qdrant
+kubectl get svc -n planifets-dev planifets-chatbot-qdrant
+```
+
+## Notes
+
+- Le stockage persistant Qdrant utilise un `volumeClaimTemplate` de `5Gi` avec `storageClassName: cephfs`.
+- Le service expose les ports `6333` (HTTP) et `6334` (gRPC).
+- Chaque overlay fixe explicitement le digest Qdrant. Pour mettre Qdrant à jour, changer d'abord le digest dev, valider, puis promouvoir exactement le même digest vers staging et prod.

--- a/apps/clubs/applets/planifets-chatbot/base/qdrant/kustomization.yaml
+++ b/apps/clubs/applets/planifets-chatbot/base/qdrant/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - statefulset.yaml
+  - service.yaml

--- a/apps/clubs/applets/planifets-chatbot/base/qdrant/service.yaml
+++ b/apps/clubs/applets/planifets-chatbot/base/qdrant/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: planifets-chatbot-qdrant
+  annotations:
+    kube-score/ignore: pod-networkpolicy, service-targets-pod
+spec:
+  selector:
+    app: planifets-chatbot-qdrant
+  clusterIP: None
+  ports:
+    - name: http
+      protocol: TCP
+      port: 6333
+      targetPort: 6333
+    - name: grpc
+      protocol: TCP
+      port: 6334
+      targetPort: 6334
+  type: ClusterIP

--- a/apps/clubs/applets/planifets-chatbot/base/qdrant/statefulset.yaml
+++ b/apps/clubs/applets/planifets-chatbot/base/qdrant/statefulset.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: planifets-chatbot-qdrant
+  annotations:
+    kube-score/ignore: pod-networkpolicy, pod-probes
+spec:
+  serviceName: planifets-chatbot-qdrant
+  replicas: 1
+  selector:
+    matchLabels:
+      app: planifets-chatbot-qdrant
+  template:
+    metadata:
+      labels:
+        app: planifets-chatbot-qdrant
+    spec:
+      securityContext:
+        fsGroup: 10001
+      volumes:
+        - name: tmp
+          emptyDir: {}
+      containers:
+        - name: qdrant
+          image: qdrant/qdrant@sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 6333
+              name: http
+            - containerPort: 6334
+              name: grpc
+          env:
+            - name: QDRANT__SERVICE__API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-chatbot-secret
+                  key: qdrant_api_key
+            - name: QDRANT__STORAGE__SNAPSHOTS_PATH
+              value: /qdrant/storage/snapshots
+            - name: QDRANT__TELEMETRY_DISABLED
+              value: "true"
+          livenessProbe:
+            tcpSocket:
+              port: 6333
+            initialDelaySeconds: 30
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 6333
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 200m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 800m
+              memory: 1Gi
+              ephemeral-storage: 1Gi
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: qdrant-storage
+              mountPath: /qdrant/storage
+            - name: tmp
+              mountPath: /tmp
+  volumeClaimTemplates:
+    - metadata:
+        name: qdrant-storage
+      spec:
+        accessModes: ["ReadWriteMany"] # for future growth and scaling
+        storageClassName: cephfs
+        resources:
+          requests:
+            storage: 5Gi

--- a/apps/clubs/applets/planifets-chatbot/dev/kustomization.yaml
+++ b/apps/clubs/applets/planifets-chatbot/dev/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/qdrant
+  - vault-secret.yaml
+
+images:
+  - name: qdrant/qdrant
+    digest: sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286

--- a/apps/clubs/applets/planifets-chatbot/dev/vault-secret.yaml
+++ b/apps/clubs/applets/planifets-chatbot/dev/vault-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-chatbot-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: qdrant
+      path: kv/data/planifets-dev/default/chatbot/qdrant
+  output:
+    name: planifets-chatbot-secret
+    stringData:
+      qdrant_api_key: '{{ .qdrant.api_key }}'
+    type: opaque

--- a/apps/clubs/applets/planifets-chatbot/planifets-chatbot-shared.argoapp.yaml
+++ b/apps/clubs/applets/planifets-chatbot/planifets-chatbot-shared.argoapp.yaml
@@ -1,0 +1,71 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: planifets-chatbot-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: applets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: planifets
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/applets/planifets-chatbot/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    automated:
+      selfHeal: true
+      prune: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: planifets-chatbot-staging-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: applets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: planifets-staging
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/applets/planifets-chatbot/staging
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    automated:
+      selfHeal: true
+      prune: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: planifets-chatbot-dev-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: applets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: planifets-dev
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/applets/planifets-chatbot/dev
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/applets/planifets-chatbot/prod/kustomization.yaml
+++ b/apps/clubs/applets/planifets-chatbot/prod/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/qdrant
+  - vault-secret.yaml
+
+images:
+  - name: qdrant/qdrant
+    digest: sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286

--- a/apps/clubs/applets/planifets-chatbot/prod/vault-secret.yaml
+++ b/apps/clubs/applets/planifets-chatbot/prod/vault-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-chatbot-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: qdrant
+      path: kv/data/planifets/default/planifets/planifets-backend
+  output:
+    name: planifets-chatbot-secret
+    stringData:
+      qdrant_api_key: '{{ .qdrant.qdrant_api_key }}'
+    type: opaque

--- a/apps/clubs/applets/planifets-chatbot/staging/kustomization.yaml
+++ b/apps/clubs/applets/planifets-chatbot/staging/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/qdrant
+  - vault-secret.yaml
+
+images:
+  - name: qdrant/qdrant
+    digest: sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286

--- a/apps/clubs/applets/planifets-chatbot/staging/vault-secret.yaml
+++ b/apps/clubs/applets/planifets-chatbot/staging/vault-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-chatbot-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: qdrant
+      path: kv/data/planifets-staging/default/chatbot/qdrant
+  output:
+    name: planifets-chatbot-secret
+    stringData:
+      qdrant_api_key: '{{ .qdrant.api_key }}'
+    type: opaque

--- a/apps/clubs/applets/planifets/base/backend/cnpg.yaml
+++ b/apps/clubs/applets/planifets/base/backend/cnpg.yaml
@@ -1,0 +1,22 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cnpg
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.2
+  instances: 1
+  bootstrap:
+    initdb:
+      database: planifetsDB
+      owner: planifets
+      secret:
+        name: cnpg-secret
+  storage:
+    size: 5Gi
+    storageClass: ceph-rbd
+  postgresql:
+    parameters:
+      max_connections: "200"
+      superuser_reserved_connections: "5"
+      statement_timeout: "30000"
+      idle_in_transaction_session_timeout: "30000"

--- a/apps/clubs/applets/planifets/base/backend/deployment.yaml
+++ b/apps/clubs/applets/planifets/base/backend/deployment.yaml
@@ -1,0 +1,141 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets-backend
+  annotations:
+    kube-score/ignore: pod-networkpolicy, pod-probes, container-image-tag
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: planifets-backend
+  template:
+    metadata:
+      labels:
+        app: planifets-backend
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - planifets-backend
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: planifets-backend
+          image: ghcr.io/applets/planifets-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          env:
+            - name: APP_ENV
+              value: production
+            - name: PORT
+              value: "3000"
+            - name: TZ
+              value: America/Toronto
+            # PostgreSQL Configuration
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: db_url
+            # Analytics
+            - name: POSTHOG_HOST
+              value: https://us.i.posthog.com
+            - name: POSTHOG_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: posthog_api_key
+            - name: CHATBOT_ENABLED
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: chatbot_enabled
+                  optional: true
+            - name: LOG_LEVELS
+              value: "log,error,warn"
+            - name: YARN_CACHE_FOLDER
+              value: /tmp/.yarn-cache
+            - name: TRANSFORMERS_CACHE_DIR
+              value: /transformers-cache
+            - name: EMBEDDING_ORT_THREADS
+              value: "2"
+            - name: QDRANT_URL
+              value: "http://planifets-chatbot-qdrant:6333"
+            - name: QDRANT_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: qdrant_api_key
+            - name: GEMINI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: gemini_api_key
+            - name: GROQ_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: groq_api_key
+            - name: NVIDIA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: planifets-secret
+                  key: nvidia_api_key
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 800m
+              memory: 700Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 2000m
+              memory: 1Gi
+              ephemeral-storage: 1Gi
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            - name: yarn-cache
+              mountPath: /tmp/.yarn-cache
+            - name: tmp
+              mountPath: /tmp
+            - name: transformers-cache
+              mountPath: /transformers-cache
+      volumes:
+        - name: yarn-cache
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
+        - name: transformers-cache
+          persistentVolumeClaim:
+            claimName: planifets-backend-transformers-cache
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: planifets-backend-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: planifets-backend
+---

--- a/apps/clubs/applets/planifets/base/backend/kustomization.yaml
+++ b/apps/clubs/applets/planifets/base/backend/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - cnpg.yaml
+  - transformers-cache-pvc.yaml

--- a/apps/clubs/applets/planifets/base/backend/service.yaml
+++ b/apps/clubs/applets/planifets/base/backend/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: planifets-backend-service
+spec:
+  selector:
+    app: planifets-backend
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/apps/clubs/applets/planifets/base/backend/transformers-cache-pvc.yaml
+++ b/apps/clubs/applets/planifets/base/backend/transformers-cache-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: planifets-backend-transformers-cache
+spec:
+  storageClassName: cephfs
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Gi

--- a/apps/clubs/applets/planifets/base/frontend/deployment.yaml
+++ b/apps/clubs/applets/planifets/base/frontend/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets
+  annotations:
+    kube-score/ignore: pod-networkpolicy, pod-probes, container-image-tag
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: planifets
+  template:
+    metadata:
+      labels:
+        app: planifets
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                      - planifets
+              topologyKey: "kubernetes.io/hostname"
+      containers:
+        - name: planifets
+          image: ghcr.io/applets/planifets-frontend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 3000
+          env:
+            - name: APP_ENV
+              value: production
+            - name: CI
+              value: "false"
+            # Analytics
+            - name: UMAMI_SCRIPT_URL
+              value: https://cloud.umami.is/script.js
+            - name: UMAMI_API_URL
+              value: https://cloud.umami.is/api/send
+          readinessProbe:
+            tcpSocket:
+              port: 3000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 3000
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 800m
+              memory: 500Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 1500m
+              memory: 750Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            runAsUser: 10001
+            runAsGroup: 10001
+            readOnlyRootFilesystem: true
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: planifets-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: planifets

--- a/apps/clubs/applets/planifets/base/frontend/kustomization.yaml
+++ b/apps/clubs/applets/planifets/base/frontend/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/apps/clubs/applets/planifets/base/frontend/service.yaml
+++ b/apps/clubs/applets/planifets/base/frontend/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: planifets-service
+spec:
+  selector:
+    app: planifets
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 3000
+      targetPort: 3000

--- a/apps/clubs/applets/planifets/dev/ingress.yaml
+++ b/apps/clubs/applets/planifets/dev/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: planifets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: planifets-dev-tls
+      hosts:
+        - planifets.dev.cedille.club
+  rules:
+    - host: planifets.dev.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: planifets-service
+                port:
+                  number: 3000
+          - pathType: Prefix
+            path: /api
+            backend:
+              service:
+                name: planifets-backend-service
+                port:
+                  number: 3000

--- a/apps/clubs/applets/planifets/dev/kustomization.yaml
+++ b/apps/clubs/applets/planifets/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/frontend
+  - ../base/backend
+  - ingress.yaml
+  - vault-secret.yaml
+
+patches:
+  - path: patch-replicas.yaml

--- a/apps/clubs/applets/planifets/dev/patch-replicas.yaml
+++ b/apps/clubs/applets/planifets/dev/patch-replicas.yaml
@@ -1,0 +1,14 @@
+# Scale down to 1 replica in dev to save resources
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets-backend
+spec:
+  replicas: 1

--- a/apps/clubs/applets/planifets/dev/vault-secret.yaml
+++ b/apps/clubs/applets/planifets/dev/vault-secret.yaml
@@ -1,0 +1,81 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-frontend-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: frontend
+      path: kv/data/planifets-dev/default/frontend
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets-dev/default/backend
+  output:
+    name: planifets-frontend-secret
+    stringData:
+      umami_website_id: '{{ .frontend.umami_website_id }}'
+      posthog_project_token: '{{ .backend.posthog_project_token }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets-dev/default/backend
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: cnpg
+      path: kv/data/planifets-dev/default/cnpg
+  output:
+    name: planifets-secret
+    stringData:
+      db_url: 'postgresql://{{ .cnpg.username }}:{{ .cnpg.password }}@cnpg-rw.planifets-dev.svc.cluster.local:5432/planifetsDB?schema=public'
+      posthog_api_key: '{{ .backend.posthog_api_key }}'
+      chatbot_enabled: '{{ .backend.chatbot_enabled }}'
+      gemini_api_key: '{{ .backend.gemini_api_key }}'
+      groq_api_key: '{{ .backend.groq_api_key }}'
+      nvidia_api_key: '{{ .backend.nvidia_api_key }}'
+      qdrant_api_key: '{{ .backend.qdrant_api_key }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: cnpg-vault-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: db
+      path: kv/data/planifets-dev/default/cnpg
+  output:
+    name: cnpg-secret
+    stringData:
+      username: '{{ .db.username }}'
+      password: '{{ .db.password }}'
+    type: kubernetes.io/basic-auth

--- a/apps/clubs/applets/planifets/planifets-shared.argoapp.yaml
+++ b/apps/clubs/applets/planifets/planifets-shared.argoapp.yaml
@@ -1,0 +1,79 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: planifets-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/applets/planifets-frontend:latest, backend=ghcr.io/applets/planifets-backend:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+    argocd-image-updater.argoproj.io/backend.update-strategy: digest
+spec:
+  project: applets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: planifets
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/applets/planifets/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: planifets-staging-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/applets/planifets-frontend:staging, backend=ghcr.io/applets/planifets-backend:staging
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+    argocd-image-updater.argoproj.io/backend.update-strategy: digest
+spec:
+  project: applets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: planifets-staging
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/applets/planifets/staging
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    automated:
+      selfHeal: true
+      prune: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: planifets-dev-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/applets/planifets-frontend:dev, backend=ghcr.io/applets/planifets-backend:dev
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+    argocd-image-updater.argoproj.io/backend.update-strategy: digest
+spec:
+  project: applets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: planifets-dev
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/applets/planifets/dev
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - PruneLast=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/applets/planifets/prod/ingress.yaml
+++ b/apps/clubs/applets/planifets/prod/ingress.yaml
@@ -1,0 +1,66 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: planifets-applets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: planifets-applets-tls
+      hosts:
+        - planifets.clubapplets.ca
+  rules:
+    - host: planifets.clubapplets.ca
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: planifets-service
+                port:
+                  number: 3000
+          - pathType: Prefix
+            path: /api
+            backend:
+              service:
+                name: planifets-backend-service
+                port:
+                  number: 3000
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: planifets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: planifets-service-tls
+      hosts:
+        - planifets.prodv2.cedille.club
+  rules:
+    - host: planifets.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: planifets-service
+                port:
+                  number: 3000
+          - pathType: Prefix
+            path: /api
+            backend:
+              service:
+                name: planifets-backend-service
+                port:
+                  number: 3000
+---

--- a/apps/clubs/applets/planifets/prod/kustomization.yaml
+++ b/apps/clubs/applets/planifets/prod/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/frontend
+  - ../base/backend
+  - ingress.yaml
+  - vault-secret.yaml

--- a/apps/clubs/applets/planifets/prod/vault-secret.yaml
+++ b/apps/clubs/applets/planifets/prod/vault-secret.yaml
@@ -1,0 +1,53 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-frontend-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: frontend
+      path: kv/data/planifets/default/planifets/planifets-frontend
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets/default/planifets/planifets-backend
+  output:
+    name: planifets-frontend-secret
+    stringData:
+      umami_website_id: '{{ .frontend.umami_website_id }}'
+      posthog_project_token: '{{ .backend.posthog_project_token }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets/default/planifets/planifets-backend
+  output:
+    name: planifets-secret
+    stringData:
+      db_url: '{{ .backend.db_url }}'
+      posthog_api_key: '{{ .backend.posthog_api_key }}'
+      chatbot_enabled: '{{ .backend.chatbot_enabled }}'
+      gemini_api_key: '{{ .backend.gemini_api_key }}'
+      groq_api_key: '{{ .backend.groq_api_key }}'
+      nvidia_api_key: '{{ .backend.nvidia_api_key }}'
+      qdrant_api_key: '{{ .backend.qdrant_api_key }}'
+    type: opaque

--- a/apps/clubs/applets/planifets/staging/ingress.yaml
+++ b/apps/clubs/applets/planifets/staging/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: planifets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: planifets-staging-tls
+      hosts:
+        - planifets.staging.cedille.club
+  rules:
+    - host: planifets.staging.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: planifets-service
+                port:
+                  number: 3000
+          - pathType: Prefix
+            path: /api
+            backend:
+              service:
+                name: planifets-backend-service
+                port:
+                  number: 3000

--- a/apps/clubs/applets/planifets/staging/kustomization.yaml
+++ b/apps/clubs/applets/planifets/staging/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base/frontend
+  - ../base/backend
+  - ingress.yaml
+  - vault-secret.yaml

--- a/apps/clubs/applets/planifets/staging/patch-replicas.yaml
+++ b/apps/clubs/applets/planifets/staging/patch-replicas.yaml
@@ -1,0 +1,14 @@
+# Scale down to 1 replica in dev to save resources
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets
+spec:
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: planifets-backend
+spec:
+  replicas: 1

--- a/apps/clubs/applets/planifets/staging/vault-secret.yaml
+++ b/apps/clubs/applets/planifets/staging/vault-secret.yaml
@@ -1,0 +1,81 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-frontend-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: frontend
+      path: kv/data/planifets-staging/default/planifets-staging/frontend
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets-staging/default/planifets-staging/backend
+  output:
+    name: planifets-frontend-secret
+    stringData:
+      umami_website_id: '{{ .frontend.umami_website_id }}'
+      posthog_project_token: '{{ .backend.posthog_project_token }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: planifets-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: backend
+      path: kv/data/planifets-staging/default/planifets-staging/backend
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: cnpg
+      path: kv/data/planifets-staging/default/planifets-staging/cnpg
+  output:
+    name: planifets-secret
+    stringData:
+      db_url: 'postgresql://{{ .cnpg.username }}:{{ .cnpg.password }}@cnpg-rw.planifets-staging.svc.cluster.local:5432/planifetsDB?schema=public'
+      posthog_api_key: '{{ .backend.posthog_api_key }}'
+      chatbot_enabled: '{{ .backend.chatbot_enabled }}'
+      gemini_api_key: '{{ .backend.gemini_api_key }}'
+      groq_api_key: '{{ .backend.groq_api_key }}'
+      nvidia_api_key: '{{ .backend.nvidia_api_key }}'
+      qdrant_api_key: '{{ .backend.qdrant_api_key }}'
+    type: opaque
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: cnpg-vault-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: db
+      path: kv/data/planifets-staging/default/planifets-staging/cnpg
+  output:
+    name: cnpg-secret
+    stringData:
+      username: '{{ .db.username }}'
+      password: '{{ .db.password }}'
+    type: kubernetes.io/basic-auth

--- a/apps/clubs/comets/data_acq/data-acq-shared.argoapp.yaml
+++ b/apps/clubs/comets/data_acq/data-acq-shared.argoapp.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: data-acq-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: data-acq
+  sources:
+    - chart: influxdb2
+      helm:
+        releaseName: influxdb2
+        valueFiles:
+          - $values-influx/apps/clubs/comets/data_acq/values.influxdb.yaml
+      repoURL: https://helm.influxdata.com
+      targetRevision: 2.1.2
+    - repoURL: https://github.com/ClubCedille/k8s-shared.git
+      ref: values-influx
+      targetRevision: HEAD
+    - chart: grafana
+      helm:
+        releaseName: grafana
+        valueFiles:
+          - $values-grafana/apps/clubs/comets/data_acq/values.grafana.yaml
+      repoURL: https://grafana.github.io/helm-charts
+      targetRevision: 10.5.15
+    - repoURL: https://github.com/ClubCedille/k8s-shared.git
+      ref: values-grafana
+      targetRevision: HEAD
+    - repoURL: https://github.com/ClubCedille/k8s-shared
+      path: apps/clubs/comets/data_acq/resources
+      targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/comets/data_acq/resources/grafana-ingress.yaml
+++ b/apps/clubs/comets/data_acq/resources/grafana-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: grafana-tls
+      hosts:
+        - grafana.prodv2.cedille.club
+  rules:
+    - host: grafana.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: grafana
+                port:
+                  number: 80

--- a/apps/clubs/comets/data_acq/resources/influxdb2-ingress.yaml
+++ b/apps/clubs/comets/data_acq/resources/influxdb2-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: influxdb2-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: influxdb2-tls
+      hosts:
+        - influxdb.prodv2.cedille.club
+  rules:
+    - host: influxdb.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: influxdb2
+                port:
+                  number: 80

--- a/apps/clubs/comets/data_acq/values.grafana.yaml
+++ b/apps/clubs/comets/data_acq/values.grafana.yaml
@@ -1,0 +1,1707 @@
+global:
+  # -- Overrides the Docker registry globally for all images
+  imageRegistry: null
+
+  # To help compatibility with other charts which use global.imagePullSecrets.
+  # Allow either an array of {name: pullSecret} maps (k8s-style), or an array of strings (more common helm-style).
+  # Can be templated.
+  # global:
+  #   imagePullSecrets:
+  #   - name: pullSecret1
+  #   - name: pullSecret2
+  # or
+  # global:
+  #   imagePullSecrets:
+  #   - pullSecret1
+  #   - pullSecret2
+  imagePullSecrets: []
+
+rbac:
+  create: true
+  ## Use an existing ClusterRole/Role (depending on rbac.namespaced false/true)
+  # useExistingRole: name-of-some-role
+  # useExistingClusterRole: name-of-some-clusterRole
+  pspEnabled: false
+  pspUseAppArmor: false
+  namespaced: false
+  extraRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   verbs: []
+  extraClusterRoleRules: []
+  # - apiGroups: []
+  #   resources: []
+  #   verbs: []
+serviceAccount:
+  create: true
+  name:
+  nameTest:
+  ## ServiceAccount labels.
+  labels: {}
+  ## Service account annotations. Can be templated.
+  #  annotations:
+  #    eks.amazonaws.com/role-arn: arn:aws:iam::123456789000:role/iam-role-name-here
+
+  ## autoMount is deprecated in favor of automountServiceAccountToken
+  # autoMount: false
+  automountServiceAccountToken: false
+
+replicas: 1
+
+## Create a headless service for the deployment
+headlessService: false
+
+## Should the service account be auto mounted on the pod
+automountServiceAccountToken: true
+
+## Create HorizontalPodAutoscaler object for deployment type
+#
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPU: "60"
+  targetMemory: ""
+  behavior: {}
+
+## See `kubectl explain poddisruptionbudget.spec` for more
+## ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
+podDisruptionBudget: {}
+#  apiVersion: ""
+#  minAvailable: 1
+#  maxUnavailable: 1
+#  unhealthyPodEvictionPolicy: IfHealthyBudget
+
+## See `kubectl explain deployment.spec.strategy` for more
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+deploymentStrategy:
+  type: RollingUpdate
+
+readinessProbe:
+  httpGet:
+    path: /api/health
+    port: grafana
+
+livenessProbe:
+  httpGet:
+    path: /api/health
+    port: grafana
+  initialDelaySeconds: 60
+  timeoutSeconds: 30
+  failureThreshold: 10
+
+## Use an alternate scheduler, e.g. "stork".
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+# schedulerName: "default-scheduler"
+
+image:
+  # -- The Docker registry
+  registry: docker.io
+  # -- Docker image repository
+  repository: grafana/grafana
+  # Overrides the Grafana image tag whose default is the chart appVersion
+  tag: ""
+  sha: ""
+  pullPolicy: IfNotPresent
+
+  ## Optionally specify an array of imagePullSecrets.
+  ## Secrets must be manually created in the namespace.
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ## Can be templated.
+  ##
+  pullSecrets: []
+  #   - myRegistrKeySecretName
+
+testFramework:
+  enabled: true
+  ## The type of Helm hook used to run this test. Defaults to test.
+  ## ref: https://helm.sh/docs/topics/charts_hooks/#the-available-hooks
+  ##
+  # hookType: test
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    repository: bats/bats
+    tag: "v1.4.1"
+  imagePullPolicy: IfNotPresent
+  securityContext: {}
+  containerSecurityContext: {}
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+
+# dns configuration for pod
+dnsPolicy: ~
+dnsConfig: {}
+  # nameservers:
+  #   - 8.8.8.8
+  #   options:
+  #   - name: ndots
+  #     value: "2"
+  #   - name: edns0
+
+hostUsers: ~
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 472
+  runAsGroup: 472
+  fsGroup: 472
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  capabilities:
+    drop:
+      - ALL
+  seccompProfile:
+    type: RuntimeDefault
+
+# Enable creating the grafana configmap
+createConfigmap: true
+
+# Extra configmaps to mount in grafana pods
+# Values are templated.
+extraConfigmapMounts: []
+  # - name: certs-configmap
+  #   mountPath: /etc/grafana/ssl/
+  #   subPath: certificates.crt # (optional)
+  #   configMap: certs-configmap
+  #   readOnly: true
+  #   optional: false
+
+
+extraEmptyDirMounts: []
+  # - name: provisioning-notifiers
+  #   mountPath: /etc/grafana/provisioning/notifiers
+
+
+# Apply extra labels to common labels.
+extraLabels: {}
+
+## Assign a PriorityClassName to pods if set
+# priorityClassName:
+
+downloadDashboardsImage:
+  # -- The Docker registry
+  registry: docker.io
+  repository: curlimages/curl
+  tag: 8.9.1
+  sha: ""
+  pullPolicy: IfNotPresent
+
+downloadDashboards:
+  env: {}
+  envFromSecret: ""
+  resources: {}
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  envValueFrom: {}
+  #  ENV_NAME:
+  #    configMapKeyRef:
+  #      name: configmap-name
+  #      key: value_key
+
+## Pod Annotations
+# podAnnotations: {}
+
+## ConfigMap Annotations
+# configMapAnnotations: {}
+  # argocd.argoproj.io/sync-options: Replace=true
+
+## Pod Labels
+# podLabels: {}
+
+podPortName: grafana
+gossipPortName: gossip
+## Deployment annotations
+# annotations: {}
+
+## Expose the grafana service to be accessed from outside the cluster (LoadBalancer service).
+## or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it.
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  enabled: true
+  type: ClusterIP
+  # Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)
+  ipFamilyPolicy: ""
+  # Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
+  ipFamilies: []
+  loadBalancerIP: ""
+  loadBalancerClass: ""
+  loadBalancerSourceRanges: []
+  port: 80
+  targetPort: 3000
+    # targetPort: 4181 To be used with a proxy extraContainer
+  ## Service annotations. Can be templated.
+  annotations: {}
+  labels: {}
+  portName: service
+  # Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+  appProtocol: ""
+  sessionAffinity: ""
+
+serviceMonitor:
+  ## If true, a ServiceMonitor CR is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator
+  ##
+  enabled: false
+  path: /metrics
+  #  namespace: monitoring  (defaults to use the namespace this chart is deployed to)
+  labels: {}
+  interval: 30s
+  scheme: http
+  tlsConfig: {}
+  scrapeTimeout: 30s
+  relabelings: []
+  metricRelabelings: []
+  basicAuth: {}
+  targetLabels: []
+
+extraExposePorts: []
+ # - name: keycloak
+ #   port: 8080
+ #   targetPort: 8080
+
+# overrides pod.spec.hostAliases in the grafana deployment's pods
+hostAliases: []
+  # - ip: "1.2.3.4"
+  #   hostnames:
+  #     - "my.host.com"
+
+ingress:
+  enabled: false
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # ingressClassName: nginx
+  # Values can be templated
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  labels: {}
+  path: /
+
+  # pathType is only for k8s >= 1.1=
+  pathType: Prefix
+
+  hosts:
+    - chart-example.local
+  ## Extra paths to prepend to every host configuration. This is useful when working with annotation based services.
+  extraPaths: []
+  # - path: /*
+  #   backend:
+  #     serviceName: ssl-redirect
+  #     servicePort: use-annotation
+  ## Or for k8s > 1.19
+  # - path: /*
+  #   pathType: Prefix
+  #   backend:
+  #     service:
+  #       name: ssl-redirect
+  #       port:
+  #         name: use-annotation
+
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# -- BETA: Configure the gateway routes for the chart here.
+# More routes can be added by adding a dictionary key like the 'main' route.
+# Be aware that this is an early beta of this feature,
+# kube-prometheus-stack does not guarantee this works and is subject to change.
+# Being BETA this can/will change in the future without notice, do not use unless you want to take that risk
+# [[ref]](https://gateway-api.sigs.k8s.io/references/spec/#gateway.networking.k8s.io%2fv1alpha2)
+route:
+  main:
+    # -- Enables or disables the route
+    enabled: false
+
+    # -- Set the route apiVersion, e.g. gateway.networking.k8s.io/v1 or gateway.networking.k8s.io/v1alpha2
+    apiVersion: gateway.networking.k8s.io/v1
+    # -- Set the route kind
+    # Valid options are GRPCRoute, HTTPRoute, TCPRoute, TLSRoute, UDPRoute
+    kind: HTTPRoute
+
+    annotations: {}
+    labels: {}
+
+    hostnames: []
+    # - my-filter.example.com
+    parentRefs: []
+    # - name: acme-gw
+
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+
+    ## Filters define the filters that are applied to requests that match this rule.
+    filters: []
+
+    ## Additional custom rules that can be added to the route
+    additionalRules: []
+
+    ## httpsRedirect adds a filter for redirecting to https (HTTP 301 Moved Permanently).
+    ## To redirect HTTP traffic to HTTPS, you need to have a Gateway with both HTTP and HTTPS listeners.
+    ## Matches and filters do not take effect if enabled.
+    ## Ref. https://gateway-api.sigs.k8s.io/guides/http-redirect-rewrite/
+    httpsRedirect: false
+
+resources: {}
+#  limits:
+#    cpu: 100m
+#    memory: 128Mi
+#  requests:
+#    cpu: 100m
+#    memory: 128Mi
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+#
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment (evaluated as template)
+## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+## Topology Spread Constraints
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+##
+topologySpreadConstraints: []
+
+## Additional init containers (evaluated as template)
+## ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+##
+extraInitContainers: []
+
+## Enable an Specify container in extraContainers. This is meant to allow adding an authentication proxy to a grafana pod
+extraContainers: ""
+# extraContainers: |
+# - name: proxy
+#   image: quay.io/gambol99/keycloak-proxy:latest
+#   args:
+#   - -provider=github
+#   - -client-id=
+#   - -client-secret=
+#   - -github-org=<ORG_NAME>
+#   - -email-domain=*
+#   - -cookie-secret=
+#   - -http-address=http://0.0.0.0:4181
+#   - -upstream-url=http://127.0.0.1:3000
+#   ports:
+#     - name: proxy-web
+#       containerPort: 4181
+
+## Volumes that can be used in init containers that will not be mounted to deployment pods
+extraContainerVolumes: []
+#  - name: volume-from-secret
+#    secret:
+#      secretName: secret-to-mount
+#  - name: empty-dir-volume
+#    emptyDir: {}
+
+## Enable persistence using Persistent Volume Claims
+## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/
+##
+persistence:
+  type: pvc
+  enabled: true
+  storageClassName: cephfs
+  ## (Optional) Use this to bind the claim to an existing PersistentVolume (PV) by name.
+  volumeName: ""
+  accessModes:
+    - ReadWriteOnce
+  size: 20Gi
+  # annotations: {}
+  finalizers:
+    - kubernetes.io/pvc-protection
+  # selectorLabels: {}
+  ## Sub-directory of the PV to mount. Can be templated.
+  # subPath: ""
+  ## Name of an existing PVC. Can be templated.
+  # existingClaim:
+  ## Extra labels to apply to a PVC.
+  extraPvcLabels: {}
+  disableWarning: false
+
+  ## If persistence is not enabled, this allows to mount the
+  ## local storage in-memory to improve performance
+  ##
+  inMemory:
+    enabled: false
+    ## The maximum usage on memory medium EmptyDir would be
+    ## the minimum value between the SizeLimit specified
+    ## here and the sum of memory limits of all containers in a pod
+    ##
+    # sizeLimit: 300Mi
+
+  ## If 'lookupVolumeName' is set to true, Helm will attempt to retrieve
+  ## the current value of 'spec.volumeName' and incorporate it into the template.
+  lookupVolumeName: true
+
+initChownData:
+  ## If false, data ownership will not be reset at startup
+  ## This allows the grafana-server to be run with an arbitrary user
+  ##
+  enabled: true
+
+  ## initChownData container image
+  ##
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    repository: library/busybox
+    tag: "1.31.1"
+    sha: ""
+    pullPolicy: IfNotPresent
+
+  ## initChownData resource requests and limits
+  ## Ref: http://kubernetes.io/docs/user-guide/compute-resources/
+  ##
+  resources: {}
+  #  limits:
+  #    cpu: 100m
+  #    memory: 128Mi
+  #  requests:
+  #    cpu: 100m
+  #    memory: 128Mi
+  securityContext:
+    readOnlyRootFilesystem: false
+    runAsNonRoot: false
+    runAsUser: 0
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      add:
+        - CHOWN
+      drop:
+        - ALL
+
+# Administrator credentials when not using an existing secret (see below)
+adminUser: admin
+# adminPassword: strongpassword
+
+# Use an existing secret for the admin user.
+admin:
+  ## Name of the secret. Can be templated.
+  existingSecret: "secret-comets-grafana-admin"
+  userKey: admin-user
+  passwordKey: admin-password
+
+## Define command to be executed at startup by grafana container
+## Needed if using `vault-env` to manage secrets (ref: https://banzaicloud.com/blog/inject-secrets-into-pods-vault/)
+## Default is "run.sh" as defined in grafana's Dockerfile
+# command:
+# - "sh"
+# - "/run.sh"
+
+## Optionally define args if command is used
+## Needed if using `hashicorp/envconsul` to manage secrets
+## By default no arguments are set
+# args:
+# - "-secret"
+# - "secret/grafana"
+# - "./grafana"
+
+## Extra environment variables that will be pass onto deployment pods
+##
+## to provide grafana with access to CloudWatch on AWS EKS:
+## 1. create an iam role of type "Web identity" with provider oidc.eks.* (note the provider for later)
+## 2. edit the "Trust relationships" of the role, add a line inside the StringEquals clause using the
+## same oidc eks provider as noted before (same as the existing line)
+## also, replace NAMESPACE and prometheus-operator-grafana with the service account namespace and name
+##
+##  "oidc.eks.us-east-1.amazonaws.com/id/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX:sub": "system:serviceaccount:NAMESPACE:prometheus-operator-grafana",
+##
+## 3. attach a policy to the role, you can use a built in policy called CloudWatchReadOnlyAccess
+## 4. use the following env: (replace 123456789000 and iam-role-name-here with your aws account number and role name)
+##
+## env:
+##   AWS_ROLE_ARN: arn:aws:iam::123456789000:role/iam-role-name-here
+##   AWS_WEB_IDENTITY_TOKEN_FILE: /var/run/secrets/eks.amazonaws.com/serviceaccount/token
+##   AWS_REGION: us-east-1
+##
+## 5. uncomment the EKS section in extraSecretMounts: below
+## 6. uncomment the annotation section in the serviceAccount: above
+## make sure to replace arn:aws:iam::123456789000:role/iam-role-name-here with your role arn
+
+env: {}
+
+## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+## Renders in container spec as:
+##   env:
+##     ...
+##     - name: <key>
+##       valueFrom:
+##         <value rendered as YAML>
+envValueFrom: {}
+  #  ENV_NAME:
+  #    configMapKeyRef:
+  #      name: configmap-name
+  #      key: value_key
+
+## The name of a secret in the same kubernetes namespace which contain values to be added to the environment
+## This can be useful for auth tokens, etc. Value is templated.
+envFromSecret: ""
+
+## Sensible environment variables that will be rendered as new secret object
+## This can be useful for auth tokens, etc.
+## If the secret values contains "{{", they'll need to be properly escaped so that they are not interpreted by Helm
+## ref: https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function
+envRenderSecret: {}
+
+## The names of secrets in the same kubernetes namespace which contain values to be added to the environment
+## Each entry should contain a name key, and can optionally specify whether the secret must be defined with an optional key.
+## Name is templated.
+envFromSecrets: []
+## - name: secret-name
+##   prefix: prefix
+##   optional: true
+
+## The names of configmaps in the same kubernetes namespace which contain values to be added to the environment
+## Each entry should contain a name key, and can optionally specify whether the configmap must be defined with an optional key.
+## Name is templated.
+## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.23/#configmapenvsource-v1-core
+envFromConfigMaps: []
+## - name: configmap-name
+##   prefix: prefix
+##   optional: true
+
+# Inject Kubernetes services as environment variables.
+# See https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables
+enableServiceLinks: true
+
+## Additional grafana server secret mounts
+# Defines additional mounts with secrets. Secrets must be manually created in the namespace.
+extraSecretMounts: []
+  # - name: secret-files
+  #   mountPath: /etc/secrets
+  #   secretName: grafana-secret-files
+  #   readOnly: true
+  #   optional: false
+  #   subPath: ""
+  #
+  # for AWS EKS (cloudwatch) use the following (see also instruction in env: above)
+  # - name: aws-iam-token
+  #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+  #   readOnly: true
+  #   projected:
+  #     defaultMode: 420
+  #     sources:
+  #       - serviceAccountToken:
+  #           audience: sts.amazonaws.com
+  #           expirationSeconds: 86400
+  #           path: token
+  #
+  # for CSI e.g. Azure Key Vault use the following
+  # - name: secrets-store-inline
+  #  mountPath: /run/secrets/vault.azure.com
+  #  readOnly: true
+  #  csi:
+  #    driver: secrets-store.csi.k8s.io
+  #    readOnly: true
+  #    volumeAttributes:
+  #      secretProviderClass: "akv-grafana-spc"
+  #    nodePublishSecretRef:                       # Only required when using service principal mode
+  #       name: grafana-akv-creds                  # Only required when using service principal mode
+
+## Additional grafana server volume mounts
+# Defines additional volume mounts.
+extraVolumeMounts: []
+  # - name: extra-volume-0
+  #   mountPath: /mnt/volume0
+  #   readOnly: true
+  # - name: extra-volume-1
+  #   mountPath: /mnt/volume1
+  #   readOnly: true
+  # - name: grafana-secrets
+  #   mountPath: /mnt/volume2
+
+## Additional Grafana server volumes
+extraVolumes: []
+  # - name: extra-volume-0
+  #   existingClaim: volume-claim
+  # - name: extra-volume-1
+  #   hostPath:
+  #     path: /usr/shared/
+  #     type: ""
+  # - name: grafana-secrets
+  #   csi:
+  #     driver: secrets-store.csi.k8s.io
+  #     readOnly: true
+  #     volumeAttributes:
+  #       secretProviderClass: "grafana-env-spc"
+
+## Container Lifecycle Hooks. Execute a specific bash command or make an HTTP request
+lifecycleHooks: {}
+  # postStart:
+  #   exec:
+  #     command: []
+
+## Pass the plugins you want installed as a list.
+##
+plugins: []
+  # - digrich-bubblechart-panel
+  # - grafana-clock-panel
+  ## You can also use other plugin download URL, as long as they are valid zip files,
+  ## and specify the name of the plugin after the semicolon. Like this:
+  # - https://grafana.com/api/plugins/marcusolsson-json-datasource/versions/1.3.2/download;marcusolsson-json-datasource
+
+## Configure grafana datasources
+## ref: http://docs.grafana.org/administration/provisioning/#datasources
+##
+datasources: {}
+#  datasources.yaml:
+#    apiVersion: 1
+#    datasources:
+#    - name: Prometheus
+#      type: prometheus
+#      url: http://prometheus-prometheus-server
+#      access: proxy
+#      isDefault: true
+#    - name: CloudWatch
+#      type: cloudwatch
+#      access: proxy
+#      uid: cloudwatch
+#      editable: false
+#      jsonData:
+#        authType: default
+#        defaultRegion: us-east-1
+#    deleteDatasources: []
+#    - name: Prometheus
+
+## Configure grafana alerting (can be templated)
+## ref: https://docs.grafana.com/alerting/set-up/provision-alerting-resources/file-provisioning/
+##
+alerting: {}
+  # policies.yaml:
+  #   apiVersion: 1
+  #   policies:
+  #     - orgId: 1
+  #       receiver: first_uid
+  #
+  # rules.yaml:
+  #   apiVersion: 1
+  #   groups:
+  #     - orgId: 1
+  #       name: '{{ .Chart.Name }}_my_rule_group'
+  #       folder: my_first_folder
+  #       interval: 60s
+  #       rules:
+  #         - uid: my_id_1
+  #           title: my_first_rule
+  #           condition: A
+  #           data:
+  #             - refId: A
+  #               datasourceUid: '-100'
+  #               model:
+  #                 conditions:
+  #                   - evaluator:
+  #                       params:
+  #                         - 3
+  #                       type: gt
+  #                     operator:
+  #                       type: and
+  #                     query:
+  #                       params:
+  #                         - A
+  #                     reducer:
+  #                       type: last
+  #                     type: query
+  #                 datasource:
+  #                   type: __expr__
+  #                   uid: '-100'
+  #                 expression: 1==0
+  #                 intervalMs: 1000
+  #                 maxDataPoints: 43200
+  #                 refId: A
+  #                 type: math
+  #           dashboardUid: my_dashboard
+  #           panelId: 123
+  #           noDataState: Alerting
+  #           for: 60s
+  #           annotations:
+  #             some_key: some_value
+  #           labels:
+  #             team: sre_team_1
+  #
+  # contactpoints.yaml:
+  #   secret:
+  #     apiVersion: 1
+  #     contactPoints:
+  #       - orgId: 1
+  #         name: cp_1
+  #         receivers:
+  #           - uid: first_uid
+  #             type: pagerduty
+  #             settings:
+  #               integrationKey: XXX
+  #               severity: critical
+  #               class: ping failure
+  #               component: Grafana
+  #               group: app-stack
+  #               summary: |
+  #                 {{ `{{ include "default.message" . }}` }}
+  #
+  # templates.yaml:
+  #   apiVersion: 1
+  #   templates:
+  #     - orgId: 1
+  #       name: my_first_template
+  #       template: |
+  #         {{ `
+  #         {{ define "my_first_template" }}
+  #         Custom notification message
+  #         {{ end }}
+  #         ` }}
+  #
+  # mutetimes.yaml
+  #   apiVersion: 1
+  #   muteTimes:
+  #     - orgId: 1
+  #       name: mti_1
+  #       # refer to https://prometheus.io/docs/alerting/latest/configuration/#time_interval-0
+  #       time_intervals: {}
+
+## Configure notifiers
+## ref: http://docs.grafana.org/administration/provisioning/#alert-notification-channels
+##
+notifiers: {}
+#  notifiers.yaml:
+#    notifiers:
+#    - name: email-notifier
+#      type: email
+#      uid: email1
+#      # either:
+#      org_id: 1
+#      # or
+#      org_name: Main Org.
+#      is_default: true
+#      settings:
+#        addresses: an_email_address@example.com
+#    delete_notifiers:
+
+## Configure grafana dashboard providers
+## ref: http://docs.grafana.org/administration/provisioning/#dashboards
+##
+## `path` must be /var/lib/grafana/dashboards/<provider_name>
+##
+dashboardProviders: {}
+#  dashboardproviders.yaml:
+#    apiVersion: 1
+#    providers:
+#    - name: 'default'
+#      orgId: 1
+#      folder: ''
+#      type: file
+#      disableDeletion: false
+#      editable: true
+#      options:
+#        path: /var/lib/grafana/dashboards/default
+
+## Configure how curl fetches remote dashboards. The beginning dash is required.
+## NOTE: This sets the default short flags for all dashboards, but these
+##       defaults can be overridden individually for each dashboard by setting
+##       curlOptions. See the example dashboards section below.
+##
+## -s  - silent mode
+## -k  - allow insecure (eg: non-TLS) connections
+## -f  - fail fast
+## See the curl documentation for additional options
+##
+defaultCurlOptions: "-skf"
+
+## Configure grafana dashboard to import
+## NOTE: To use dashboards you must also enable/configure dashboardProviders
+## ref: https://grafana.com/dashboards
+##
+## dashboards per provider, use provider name as key.
+##
+dashboards: {}
+  # default:
+  #   some-dashboard:
+  #     json: |
+  #       $RAW_JSON
+  #   custom-dashboard:
+  #     file: dashboards/custom-dashboard.json
+  #   prometheus-stats:
+  #     gnetId: 2
+  #     revision: 2
+  #     datasource: Prometheus
+  #   local-dashboard:
+  #     url: https://example.com/repository/test.json
+  #     curlOptions: "-sLf"
+  #     token: ''
+  #   local-dashboard-base64:
+  #     url: https://example.com/repository/test-b64.json
+  #     token: ''
+  #     b64content: true
+  #   local-dashboard-gitlab:
+  #     url: https://example.com/repository/test-gitlab.json
+  #     gitlabToken: ''
+  #   local-dashboard-bitbucket:
+  #     url: https://example.com/repository/test-bitbucket.json
+  #     bearerToken: ''
+  #   local-dashboard-azure:
+  #     url: https://example.com/repository/test-azure.json
+  #     basic: ''
+  #     acceptHeader: '*/*'
+
+## Reference to external ConfigMap per provider. Use provider name as key and ConfigMap name as value.
+## A provider dashboards must be defined either by external ConfigMaps or in values.yaml, not in both.
+## ConfigMap data example:
+##
+## data:
+##   example-dashboard.json: |
+##     RAW_JSON
+##
+dashboardsConfigMaps: {}
+#  default: ""
+
+## Grafana's primary configuration
+## NOTE: values in map will be converted to ini format
+## ref: http://docs.grafana.org/installation/configuration/
+##
+grafana.ini:
+  paths:
+    data: /var/lib/grafana/
+    logs: /var/log/grafana
+    plugins: /var/lib/grafana/plugins
+    provisioning: /etc/grafana/provisioning
+  analytics:
+    check_for_updates: true
+  log:
+    mode: console
+  server:
+    domain: "{{ if (and .Values.ingress.enabled .Values.ingress.hosts) }}{{ tpl (.Values.ingress.hosts | first) . }}{{ else if (and .Values.route.main.enabled .Values.route.main.hostnames) }}{{ tpl (.Values.route.main.hostnames | first) . }}{{ else }}''{{ end }}"
+  unified_storage:
+    index_path: /var/lib/grafana-search/bleve
+## grafana Authentication can be enabled with the following values on grafana.ini
+ # server:
+      # The full public facing url you use in browser, used for redirects and emails
+ #    root_url:
+ # https://grafana.com/docs/grafana/latest/auth/github/#enable-github-in-grafana
+ # auth.github:
+ #    enabled: false
+ #    allow_sign_up: false
+ #    scopes: user:email,read:org
+ #    auth_url: https://github.com/login/oauth/authorize
+ #    token_url: https://github.com/login/oauth/access_token
+ #    api_url: https://api.github.com/user
+ #    team_ids:
+ #    allowed_organizations:
+ #    client_id:
+ #    client_secret:
+## LDAP Authentication can be enabled with the following values on grafana.ini
+## NOTE: Grafana will fail to start if the value for ldap.toml is invalid
+  # auth.ldap:
+  #   enabled: true
+  #   allow_sign_up: true
+  #   config_file: /etc/grafana/ldap.toml
+## Grafana's alerting configuration
+  # unified_alerting:
+  #   enabled: true
+  #   rule_version_record_limit: "5"
+
+## Grafana's LDAP configuration
+## Templated by the template in _helpers.tpl
+## NOTE: To enable the grafana.ini must be configured with auth.ldap.enabled
+## ref: http://docs.grafana.org/installation/configuration/#auth-ldap
+## ref: http://docs.grafana.org/installation/ldap/#configuration
+ldap:
+  enabled: false
+  # `existingSecret` is a reference to an existing secret containing the ldap configuration
+  # for Grafana in a key `ldap-toml`.
+  existingSecret: ""
+  # `config` is the content of `ldap.toml` that will be stored in the created secret
+  config: ""
+  # config: |-
+  #   verbose_logging = true
+
+  #   [[servers]]
+  #   host = "my-ldap-server"
+  #   port = 636
+  #   use_ssl = true
+  #   start_tls = false
+  #   ssl_skip_verify = false
+  #   bind_dn = "uid=%s,ou=users,dc=myorg,dc=com"
+
+# When process namespace sharing is enabled, processes in a container are visible to all other containers in the same pod
+# This parameter is added because the ldap reload api is not working https://grafana.com/docs/grafana/latest/developers/http_api/admin/#reload-ldap-configuration
+# To allow an extraContainer to restart the Grafana container
+shareProcessNamespace: false
+
+## Grafana's SMTP configuration
+## NOTE: To enable, grafana.ini must be configured with smtp.enabled
+## ref: http://docs.grafana.org/installation/configuration/#smtp
+smtp:
+  # `existingSecret` is a reference to an existing secret containing the smtp configuration
+  # for Grafana.
+  existingSecret: ""
+  userKey: "user"
+  passwordKey: "password"
+
+## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
+## Requires at least Grafana 5 to work and can't be used together with parameters dashboardProviders, datasources and dashboards
+sidecar:
+  image:
+    # -- The Docker registry
+    registry: quay.io
+    repository: kiwigrid/k8s-sidecar
+    tag: 2.5.0
+    sha: ""
+  imagePullPolicy: IfNotPresent
+  resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    seccompProfile:
+      type: RuntimeDefault
+  # skipTlsVerify Set to true to skip tls verification for kube api calls
+  # skipTlsVerify: true
+  enableUniqueFilenames: false
+  readinessProbe: {}
+  livenessProbe: {}
+  # Log level default for all sidecars. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL. Defaults to INFO
+  # logLevel: INFO
+  alerts:
+    enabled: false
+    # Additional environment variables for the alerts sidecar
+    env: {}
+    ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+    ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+    ## Renders in container spec as:
+    ##   env:
+    ##     ...
+    ##     - name: <key>
+    ##       valueFrom:
+    ##         <value rendered as YAML>
+    envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with alert are marked with (can be templated)
+    label: grafana_alert
+    # value of label that the configmaps with alert are set to (can be templated)
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for alert config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.alerts.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/alerts-1,configmap/alerts-0"
+    resourceName: ""
+    #
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # maxTotalRetries: Total number of retries to allow for any http request.
+    # Takes precedence over other counts. Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry.
+    # maxTotalRetries: 5
+    #
+    # maxConnectRetries: How many connection-related errors to retry on for any http request.
+    # These are errors raised before the request is sent to the remote server, which we assume has not triggered the server to process the request.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxConnectRetries: 10
+    #
+    # maxReadRetries: How many times to retry on read errors for any http request
+    # These errors are raised after the request was sent to the server, so the request may have side-effects.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxReadRetries: 5
+    #
+    # Endpoint to send request to reload alerts
+    reloadURL: "http://localhost:3000/api/admin/provisioning/alerting/reload"
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
+    script: null
+    skipReload: false
+    # This is needed if skipReload is true, to load any alerts defined at startup time.
+    # Deploy the alert sidecar as an initContainer.
+    initAlerts: false
+    # Use native sidecar https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+    # restartPolicy: Always
+    # # only applies to native sidecars
+    # startupProbe:
+    #   httpGet:
+    #     path: /healthz
+    #     port: 8080
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 5
+    #   failureThreshold: 60 # 5 minutes
+    # Additional alerts sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the alert sidecar emptyDir volume
+    sizeLimit: ""
+  dashboards:
+    enabled: false
+    # Additional environment variables for the dashboards sidecar
+    env: {}
+    ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+    ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+    ## Renders in container spec as:
+    ##   env:
+    ##     ...
+    ##     - name: <key>
+    ##       valueFrom:
+    ##         <value rendered as YAML>
+    envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    SCProvider: true
+    # label that the configmaps with dashboards are marked with (can be templated)
+    label: grafana_dashboard
+    # value of label that the configmaps with dashboards are set to (can be templated)
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # folder in the pod that should hold the collected dashboards (unless `defaultFolderName` is set)
+    folder: /tmp/dashboards
+    # The default folder name, it will create a subfolder under the `folder` and put dashboards in there instead
+    defaultFolderName: null
+    # Namespaces list. If specified, the sidecar will search for config-maps/secrets inside these namespaces.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces.
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    # If specified, the sidecar will look for annotation with this name to create folder and put graph here.
+    # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
+    folderAnnotation: null
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.dashboards.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/dashboards-0,configmap/dashboards-1"
+    resourceName: ""
+    #
+    # maxTotalRetries: Total number of retries to allow for any http request.
+    # Takes precedence over other counts. Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry.
+    # maxTotalRetries: 5
+    #
+    # maxConnectRetries: How many connection-related errors to retry on for any http request.
+    # These are errors raised before the request is sent to the remote server, which we assume has not triggered the server to process the request.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxConnectRetries: 10
+    #
+    # maxReadRetries: How many times to retry on read errors for any http request
+    # These errors are raised after the request was sent to the server, so the request may have side-effects.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxReadRetries: 5
+    #
+    # Endpoint to send request to reload alerts
+    reloadURL: "http://localhost:3000/api/admin/provisioning/dashboards/reload"
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
+    script: null
+    skipReload: false
+    # This is needed if skipReload is true, to load any dashboards defined at startup time.
+    # Deploy the dashboard sidecar as an initContainer.
+    initDashboards: false
+    # Use native sidecar https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+    # restartPolicy: Always
+    # # only applies to native sidecars
+    # startupProbe:
+    #   httpGet:
+    #     path: /healthz
+    #     port: 8083
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 5
+    #   failureThreshold: 60 # 5 minutes
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # provider configuration that lets grafana manage the dashboards
+    provider:
+      # name of the provider, should be unique
+      name: sidecarProvider
+      # orgid as configured in grafana
+      orgid: 1
+      # folder in which the dashboards should be imported in grafana
+      folder: ''
+      # <string> folder UID. will be automatically generated if not specified
+      folderUid: ''
+      # type of the provider
+      type: file
+      # disableDelete to activate a import-only behaviour
+      disableDelete: false
+      # allow updating provisioned dashboards from the UI
+      allowUiUpdates: false
+      # allow Grafana to replicate dashboard structure from filesystem
+      foldersFromFilesStructure: false
+    # Additional dashboards sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the dashboard sidecar emptyDir volume
+    sizeLimit: ""
+  datasources:
+    enabled: false
+    # Additional environment variables for the datasourcessidecar
+    env: {}
+    ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+    ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+    ## Renders in container spec as:
+    ##   env:
+    ##     ...
+    ##     - name: <key>
+    ##       valueFrom:
+    ##         <value rendered as YAML>
+    envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with datasources are marked with (can be templated)
+    label: grafana_datasource
+    # value of label that the configmaps with datasources are set to (can be templated)
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for datasource config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.datasources.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/datasources-0,configmap/datasources-15"
+    resourceName: ""
+    #
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # maxTotalRetries: Total number of retries to allow for any http request.
+    # Takes precedence over other counts. Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry.
+    # maxTotalRetries: 5
+    #
+    # maxConnectRetries: How many connection-related errors to retry on for any http request.
+    # These are errors raised before the request is sent to the remote server, which we assume has not triggered the server to process the request.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxConnectRetries: 10
+    #
+    # maxReadRetries: How many times to retry on read errors for any http request
+    # These errors are raised after the request was sent to the server, so the request may have side-effects.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxReadRetries: 5
+    #
+    # Endpoint to send request to reload datasources
+    reloadURL: "http://localhost:3000/api/admin/provisioning/datasources/reload"
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
+    script: null
+    skipReload: false
+    # This is needed if skipReload is true, to load any datasources defined at startup time.
+    # Deploy the datasources sidecar as an initContainer.
+    initDatasources: false
+    # Use native sidecar https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+    # restartPolicy: Always
+    # # only applies to native sidecars
+    # startupProbe:
+    #   httpGet:
+    #     path: /healthz
+    #     port: 8081
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 5
+    #   failureThreshold: 60 # 5 minutes
+    # Additional datasources sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the datasource sidecar emptyDir volume
+    sizeLimit: ""
+  plugins:
+    enabled: false
+    # Additional environment variables for the plugins sidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with plugins are marked with (can be templated)
+    label: grafana_plugin
+    # value of label that the configmaps with plugins are set to (can be templated)
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for plugin config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.plugins.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/plugins-0,configmap/plugins-1"
+    resourceName: ""
+    #
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # maxTotalRetries: Total number of retries to allow for any http request.
+    # Takes precedence over other counts. Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry.
+    # maxTotalRetries: 5
+    #
+    # maxConnectRetries: How many connection-related errors to retry on for any http request.
+    # These are errors raised before the request is sent to the remote server, which we assume has not triggered the server to process the request.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxConnectRetries: 10
+    #
+    # maxReadRetries: How many times to retry on read errors for any http request
+    # These errors are raised after the request was sent to the server, so the request may have side-effects.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxReadRetries: 5
+    #
+    # Endpoint to send request to reload plugins
+    reloadURL: "http://localhost:3000/api/admin/provisioning/plugins/reload"
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
+    script: null
+    skipReload: false
+    # Deploy the datasource sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any plugins defined at startup time.
+    initPlugins: false
+    # Additional plugins sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the plugin sidecar emptyDir volume
+    sizeLimit: ""
+  notifiers:
+    enabled: false
+    # Additional environment variables for the notifierssidecar
+    env: {}
+    # Do not reprocess already processed unchanged resources on k8s API reconnect.
+    # ignoreAlreadyProcessed: true
+    # label that the configmaps with notifiers are marked with (can be templated)
+    label: grafana_notifier
+    # value of label that the configmaps with notifiers are set to (can be templated)
+    labelValue: ""
+    # Log level. Can be one of: DEBUG, INFO, WARN, ERROR, CRITICAL.
+    # logLevel: INFO
+    # If specified, the sidecar will search for notifier config-maps inside this namespace.
+    # Otherwise the namespace in which the sidecar is running will be used.
+    # It's also possible to specify ALL to search in all namespaces
+    searchNamespace: null
+    # Method to use to detect ConfigMap changes. With WATCH the sidecar will do a WATCH requests, with SLEEP it will list all ConfigMaps, then sleep for 60 seconds.
+    watchMethod: WATCH
+    # search in configmap, secret or both
+    resource: both
+    #
+    # resourceName: comma separated list of resource names to be fetched/checked by this sidecar.
+    # per default all resources of the type defined in {{ .Values.sidecar.notifiers.resource }} will be checked.
+    # This e.g. allows stricter RBAC rules which are limited to the resources meant for the sidecars.
+    # resourceName: "secret/notifiers-2,configmap/notifiers-1"
+    resourceName: ""
+    #
+    # watchServerTimeout: request to the server, asking it to cleanly close the connection after that.
+    # defaults to 60sec; much higher values like 3600 seconds (1h) are feasible for non-Azure K8S
+    # watchServerTimeout: 3600
+    #
+    # watchClientTimeout: is a client-side timeout, configuring your local socket.
+    # If you have a network outage dropping all packets with no RST/FIN,
+    # this is how long your client waits before realizing & dropping the connection.
+    # defaults to 66sec (sic!)
+    # watchClientTimeout: 60
+    #
+    # maxTotalRetries: Total number of retries to allow for any http request.
+    # Takes precedence over other counts. Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry.
+    # maxTotalRetries: 5
+    #
+    # maxConnectRetries: How many connection-related errors to retry on for any http request.
+    # These are errors raised before the request is sent to the remote server, which we assume has not triggered the server to process the request.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxConnectRetries: 10
+    #
+    # maxReadRetries: How many times to retry on read errors for any http request
+    # These errors are raised after the request was sent to the server, so the request may have side-effects.
+    # Applies to all requests to reloadURL and k8s api requests.
+    # Set to 0 to fail on the first retry of this type.
+    # maxReadRetries: 5
+    #
+    # Endpoint to send request to reload notifiers
+    reloadURL: "http://localhost:3000/api/admin/provisioning/notifications/reload"
+    # Absolute path to a script to execute after a configmap got reloaded.
+    # It runs before calls to REQ_URI. If the file is not executable it will be passed to sh.
+    # Otherwise, it's executed as is. Shebangs known to work are #!/bin/sh and #!/usr/bin/env python
+    script: null
+    skipReload: false
+    # Deploy the notifier sidecar as an initContainer in addition to a container.
+    # This is needed if skipReload is true, to load any notifiers defined at startup time.
+    initNotifiers: false
+    # Use native sidecar https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/
+    # restartPolicy: Always
+    # # only applies to native sidecars
+    # startupProbe:
+    #   httpGet:
+    #     path: /healthz
+    #     port: 8082
+    #   initialDelaySeconds: 5
+    #   periodSeconds: 5
+    #   failureThreshold: 60 # 5 minutes
+    # Additional notifiers sidecar volume mounts
+    extraMounts: []
+    # Sets the size limit of the notifier sidecar emptyDir volume
+    sizeLimit: ""
+
+## Override the deployment namespace
+##
+namespaceOverride: ""
+
+## Number of old ReplicaSets to retain
+##
+revisionHistoryLimit: 10
+
+## Add a seperate remote image renderer deployment/service
+imageRenderer:
+  deploymentStrategy: {}
+  # Enable the image-renderer deployment & service
+  enabled: false
+  replicas: 1
+  autoscaling:
+    enabled: false
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPU: "60"
+    targetMemory: ""
+    behavior: {}
+  # The url of remote image renderer if it is not in the same namespace with the grafana instance
+  serverURL: ""
+  # The callback url of grafana instances if it is not in the same namespace with the remote image renderer
+  renderingCallbackURL: ""
+  image:
+    # -- The Docker registry
+    registry: docker.io
+    # image-renderer Image repository
+    repository: grafana/grafana-image-renderer
+    # image-renderer Image tag
+    tag: latest
+    # image-renderer Image sha (optional)
+    sha: ""
+    # image-renderer Image pull secrets (optional)
+    pullSecrets: []
+    # image-renderer ImagePullPolicy
+    pullPolicy: Always
+  # extra environment variables
+  env:
+    HTTP_HOST: "0.0.0.0"
+    # Fixes "Error: Failed to launch the browser process!\nchrome_crashpad_handler: --database is required"
+    XDG_CONFIG_HOME: /tmp/.chromium
+    XDG_CACHE_HOME: /tmp/.chromium
+    # RENDERING_ARGS: --no-sandbox,--disable-gpu,--window-size=1280x758
+    # RENDERING_MODE: clustered
+    # IGNORE_HTTPS_ERRORS: true
+
+  ## "valueFrom" environment variable references that will be added to deployment pods. Name is templated.
+  ## ref: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#envvarsource-v1-core
+  ## Renders in container spec as:
+  ##   env:
+  ##     ...
+  ##     - name: <key>
+  ##       valueFrom:
+  ##         <value rendered as YAML>
+  envValueFrom: {}
+    #  ENV_NAME:
+    #    configMapKeyRef:
+    #      name: configmap-name
+    #      key: value_key
+
+  # image-renderer deployment serviceAccount
+  serviceAccountName: ""
+  automountServiceAccountToken: false
+  # image-renderer deployment hostUsers
+  hostUsers: ~
+  # image-renderer deployment securityContext
+  securityContext: {}
+  # image-renderer deployment container securityContext
+  containerSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop: ['ALL']
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: true
+  ## image-renderer pod annotation
+  podAnnotations: {}
+  # image-renderer deployment Host Aliases
+  hostAliases: []
+  # image-renderer deployment priority class
+  priorityClassName: ''
+  service:
+    # Enable the image-renderer service
+    enabled: true
+    # image-renderer service port name
+    portName: 'http'
+    # image-renderer service port used by both service and deployment
+    port: 8081
+    targetPort: 8081
+    # Adds the appProtocol field to the image-renderer service. This allows to work with istio protocol selection. Ex: "http" or "tcp"
+    appProtocol: ""
+  serviceMonitor:
+    ## If true, a ServiceMonitor CRD is created for a prometheus operator
+    ## https://github.com/coreos/prometheus-operator
+    ##
+    enabled: false
+    path: /metrics
+    #  namespace: monitoring  (defaults to use the namespace this chart is deployed to)
+    labels: {}
+    interval: 1m
+    scheme: http
+    tlsConfig: {}
+    scrapeTimeout: 30s
+    relabelings: []
+    # See: https://doc.crds.dev/github.com/prometheus-operator/kube-prometheus/monitoring.coreos.com/ServiceMonitor/v1@v0.11.0#spec-targetLabels
+    targetLabels: []
+      # - targetLabel1
+      # - targetLabel2
+  # If https is enabled in Grafana, this needs to be set as 'https' to correctly configure the callback used in Grafana
+  grafanaProtocol: http
+  # In case a sub_path is used this needs to be added to the image renderer callback
+  grafanaSubPath: ""
+  # name of the image-renderer port on the pod
+  podPortName: http
+  # number of image-renderer replica sets to keep
+  revisionHistoryLimit: 10
+  networkPolicy:
+    # Enable a NetworkPolicy to limit inbound traffic to only the created grafana pods
+    limitIngress: true
+    # Enable a NetworkPolicy to limit outbound traffic to only the created grafana pods
+    limitEgress: false
+    # Allow additional services to access image-renderer (eg. Prometheus operator when ServiceMonitor is enabled)
+    extraIngressSelectors: []
+  resources: {}
+#   limits:
+#     cpu: 100m
+#     memory: 100Mi
+#   requests:
+#     cpu: 50m
+#     memory: 50Mi
+  ## Node labels for pod assignment
+  ## ref: https://kubernetes.io/docs/user-guide/node-selection/
+  #
+  nodeSelector: {}
+
+  ## Tolerations for pod assignment
+  ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  ##
+  tolerations: []
+
+  ## Affinity for pod assignment (evaluated as template)
+  ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+  ##
+  affinity: {}
+
+  ## Use an alternate scheduler, e.g. "stork".
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  # schedulerName: "default-scheduler"
+
+  # Extra configmaps to mount in image-renderer pods
+  extraConfigmapMounts: []
+
+  # Extra secrets to mount in image-renderer pods
+  extraSecretMounts: []
+
+  # Extra volumes to mount in image-renderer pods
+  extraVolumeMounts: []
+
+  # Extra volumes for image-renderer pods
+  extraVolumes: []
+
+networkPolicy:
+  ## @param networkPolicy.enabled Enable creation of NetworkPolicy resources. Only Ingress traffic is filtered for now.
+  ##
+  enabled: false
+  ## @param networkPolicy.allowExternal Don't require client label for connections
+  ## The Policy model to apply. When set to false, only pods with the correct
+  ## client label will have network access to  grafana port defined.
+  ## When true, grafana will accept connections from any source
+  ## (with the correct destination port).
+  ##
+  ingress: true
+  ## @param networkPolicy.ingress When true enables the creation
+  ## an ingress network policy
+  ##
+  allowExternal: true
+  ## @param networkPolicy.explicitNamespacesSelector A Kubernetes LabelSelector to explicitly select namespaces from which traffic could be allowed
+  ## If explicitNamespacesSelector is missing or set to {}, only client Pods that are in the networkPolicy's namespace
+  ## and that match other criteria, the ones that have the good label, can reach the grafana.
+  ## But sometimes, we want the grafana to be accessible to clients from other namespaces, in this case, we can use this
+  ## LabelSelector to select these namespaces, note that the networkPolicy's namespace should also be explicitly added.
+  ##
+  ## Example:
+  ## explicitNamespacesSelector:
+  ##   matchLabels:
+  ##     role: frontend
+  ##   matchExpressions:
+  ##    - {key: role, operator: In, values: [frontend]}
+  ##
+  explicitNamespacesSelector: {}
+  ##
+  ##
+  ##
+  ##
+  ##
+  ##
+  egress:
+    ## @param networkPolicy.egress.enabled When enabled, an egress network policy will be
+    ## created allowing grafana to connect to external data sources from kubernetes cluster.
+    enabled: false
+    ##
+    ## @param networkPolicy.egress.blockDNSResolution When enabled, DNS resolution will be blocked
+    ## for all pods in the grafana namespace.
+    blockDNSResolution: false
+    ##
+    ## @param networkPolicy.egress.ports Add individual ports to be allowed by the egress
+    ports: []
+    ## Add ports to the egress by specifying - port: <port number>
+    ## E.X.
+    ## - port: 80
+    ## - port: 443
+    ##
+    ## @param networkPolicy.egress.to Allow egress traffic to specific destinations
+    to: []
+    ## Add destinations to the egress by specifying - ipBlock: <CIDR>
+    ## E.X.
+    ## to:
+    ##  - namespaceSelector:
+    ##    matchExpressions:
+  ##    - {key: role, operator: In, values: [grafana]}
+  ##
+  ##
+  ##
+  ##
+  ##
+
+# Enable backward compatibility of kubernetes where version below 1.13 doesn't have the enableServiceLinks option
+enableKubeBackwardCompatibility: false
+useStatefulSet: false
+
+# extraObjects could be utilized to add dynamic manifests via values
+extraObjects: []
+# Examples:
+# extraObjects:
+# - apiVersion: kubernetes-client.io/v1
+#   kind: ExternalSecret
+#   metadata:
+#     name: grafana-secrets-{{ .Release.Name }}
+#   spec:
+#     backendType: gcpSecretsManager
+#     data:
+#     - key: grafana-admin-password
+#       name: adminPassword
+# Alternatively, you can use strings, which lets you use additional templating features:
+# extraObjects:
+# - |
+#   apiVersion: kubernetes-client.io/v1
+#   kind: ExternalSecret
+#   metadata:
+#     name: grafana-secrets-{{ .Release.Name }}
+#   spec:
+#     backendType: gcpSecretsManager
+#     data:
+#     - key: grafana-admin-password
+#       name: {{ include "some-other-template" }}
+
+# assertNoLeakedSecrets is a helper function defined in _helpers.tpl that checks if secret
+# values are not exposed in the rendered grafana.ini configmap. It is enabled by default.
+#
+# To pass values into grafana.ini without exposing them in a configmap, use variable expansion:
+# https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#variable-expansion
+#
+# Alternatively, if you wish to allow secret values to be exposed in the rendered grafana.ini configmap,
+# you can disable this check by setting assertNoLeakedSecrets to false.
+assertNoLeakedSecrets: true

--- a/apps/clubs/comets/data_acq/values.influxdb.yaml
+++ b/apps/clubs/comets/data_acq/values.influxdb.yaml
@@ -1,0 +1,196 @@
+image:
+  repository: influxdb
+  tag: 2.7.4-alpine
+  pullPolicy: IfNotPresent
+  ## If specified, use these secrets to access the images
+  # pullSecrets:
+  #   - registry-secret
+
+## Annotations to be added to InfluxDB pods
+##
+podAnnotations: {}
+
+## Labels to be added to InfluxDB pods
+##
+podLabels: {}
+
+nameOverride: ""
+fullnameOverride: ""
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## Node labels for pod assignment
+## ref: https://kubernetes.io/docs/user-guide/node-selection/
+##
+nodeSelector: {}
+
+## Tolerations for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+##
+tolerations: []
+
+## Affinity for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: {}
+
+securityContext: {}
+
+## Customize liveness, readiness and startup probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+##
+livenessProbe: {}
+  # path: "/health"
+  # scheme: "HTTP"
+  # initialDelaySeconds: 0
+  # periodSeconds: 10
+  # timeoutSeconds: 1
+  # failureThreshold: 3
+
+readinessProbe: {}
+  # path: "/health"
+  # scheme: "HTTP"
+  # initialDelaySeconds: 0
+  # periodSeconds: 10
+  # timeoutSeconds: 1
+  # successThreshold: 1
+  # failureThreshold: 3
+
+startupProbe:
+  enabled: false
+  # path: "/health"
+  # scheme: "HTTP"
+  # initialDelaySeconds: 30
+  # periodSeconds: 5
+  # timeoutSeconds: 1
+  # failureThreshold: 6
+
+## Extra environment variables to configure influxdb
+## e.g.
+# env:
+#   - name: FOO
+#     value: BAR
+#   - name: BAZ
+#     valueFrom:
+#       secretKeyRef:
+#         name: my-secret
+#         key: my-key
+env: {}
+
+## Create default user through docker entrypoint
+## Defaults indicated below
+##
+adminUser:
+  organization: "influxdata"
+  bucket: "default"
+  user: "admin"
+  retention_policy: "0s"
+  ## Leave empty to generate a random password and token.
+  ## Or fill any of these values to use fixed values.
+  password: ""
+  token: ""
+
+  ## The password and token are obtained from an existing secret. The expected
+  ## keys are `admin-password` and `admin-token`.
+  ## If set, the password and token values above are ignored.
+  existingSecret: influxdb-auth
+
+## Persist data to a persistent volume
+##
+persistence:
+  enabled: true
+  ## If true will use an existing PVC instead of creating one
+  # useExisting: false
+  ## Name of existing PVC to be used in the influx deployment
+  # name:
+  ## influxdb data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  accessMode: ReadWriteOnce
+  size: 50Gi
+  mountPath: /var/lib/influxdb2
+  subPath: ""
+
+## Add custom volume and volumeMounts
+##
+# volumes:
+#   - name: influxdb2-templates
+#     hostPath:
+#       path: /data/influxdb2-templates
+#       type: Directory
+# mountPoints:
+#   - name: influxdb2-templates
+#     mountPath: /influxdb2-templates
+#     readOnly: true
+
+## Allow executing custom init scripts
+## If the container finds any files with the .sh extension inside of the
+## /docker-entrypoint-initdb.d folder, it will execute them.
+## When multiple scripts are present, they will be executed in lexical sort order by name.
+## For more details see Custom Initialization Scripts in https://hub.docker.com/_/influxdb
+initScripts:
+  enabled: false
+  scripts:
+    init.sh: |+
+      #!/bin/bash
+      influx apply --force yes -u https://raw.githubusercontent.com/influxdata/community-templates/master/influxdb2_operational_monitoring/influxdb2_operational_monitoring.yml
+
+## Specify a service type
+## ref: http://kubernetes.io/docs/user-guide/services/
+##
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8086
+  annotations: {}
+  labels: {}
+  portName: http
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+  # Annotations for the ServiceAccount
+  annotations: {}
+
+ingress:
+  enabled: false
+  # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+  # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+  # className: nginx
+  tls: false
+  # secretName: my-tls-cert # only needed if tls above is true or default certificate is not configured for Nginx
+  hostname: influxdb.foobar.com
+  annotations: {}
+    # kubernetes.io/ingress.class: "nginx"
+    # kubernetes.io/tls-acme: "true"
+  path: /
+
+## Pod disruption budget configuration
+##
+pdb:
+  ## Specifies whether a Pod disruption budget should be created
+  ##
+  create: true
+  minAvailable: 1
+  # maxUnavailable: 1

--- a/apps/clubs/forom/base/configMap.yaml
+++ b/apps/clubs/forom/base/configMap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-config
+data:
+  custom-nginx.conf: |
+    server {
+      listen 8080;
+      server_name _;
+
+      root /usr/share/nginx/html;
+      index index.html;
+
+      location / {
+        try_files $uri $uri/ /index.html;
+      }
+    }

--- a/apps/clubs/forom/base/deployment.yaml
+++ b/apps/clubs/forom/base/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: forom
+  annotations:
+    kube-score/ignore: container-image-pull-policy,container-image-tag, pod-networkpolicy
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: forom
+  template:
+    metadata:
+      labels:
+        app: forom
+    spec:
+      containers:
+        - name: forom
+          image: ghcr.io/clubcedille/forom:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: nginx-temp
+              mountPath: /var/cache/nginx
+            - name: config-volume
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+            - name: run-volume
+              mountPath: /var/run
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+              ephemeral-storage: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 10001
+            runAsGroup: 10001
+      volumes:
+        - name: nginx-temp
+          emptyDir: {}
+        - name: config-volume
+          configMap:
+            name: nginx-config
+        - name: run-volume
+          emptyDir: {}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: forom-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: forom

--- a/apps/clubs/forom/base/kustomization.yaml
+++ b/apps/clubs/forom/base/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - configMap.yaml

--- a/apps/clubs/forom/base/service.yaml
+++ b/apps/clubs/forom/base/service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: forom-service
+spec:
+  type: ClusterIP
+  clusterIP: None
+  selector:
+    app: forom
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/apps/clubs/forom/forom-shared.argoapp.yaml
+++ b/apps/clubs/forom/forom-shared.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: forom-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/clubcedille/forom:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: forom
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/forom/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/forom/prod/ingress.yaml
+++ b/apps/clubs/forom/prod/ingress.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: forom-ingress-prod
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - forom.etsmtl.ca
+      secretName: forom-tls-prod
+  rules:
+    - host: forom.etsmtl.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: forom-service
+                port:
+                  number: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: forom-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - forom.prodv2.cedille.club
+      secretName: forom-tls
+  rules:
+    - host: forom.prodv2.cedille.club
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: forom-service
+                port:
+                  number: 8080

--- a/apps/clubs/forom/prod/kustomization.yaml
+++ b/apps/clubs/forom/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml

--- a/apps/clubs/habitek/wordpress/base/db/service.yaml
+++ b/apps/clubs/habitek/wordpress/base/db/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - port: 3306
+  clusterIP: None

--- a/apps/clubs/habitek/wordpress/base/db/statefulset.yaml
+++ b/apps/clubs/habitek/wordpress/base/db/statefulset.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  annotations:
+    kube-score/ignore: >-
+      container-image-tag,
+      pod-networkpolicy,
+      container-ephemeral-storage-request-and-limit,
+      container-security-context-readonlyrootfilesystem,
+      container-security-context-user-group-id
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: mysql
+          image: mysql:latest
+          ports:
+            - containerPort: 3306
+              name: mysql
+          readinessProbe:
+            tcpSocket:
+              port: mysql
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          env:
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: habitek-secret
+                  key: MYSQL_USER
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: habitek-secret
+                  key: MYSQL_PASSWORD
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: habitek-secret
+                  key: MYSQL_DATABASE
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: habitek-secret
+                  key: MYSQL_ROOT_PASSWORD
+          volumeMounts:
+            - name: mysql-pv-claim
+              mountPath: /var/lib/mysql
+          resources:
+            requests:
+              cpu: 300m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-pv-claim
+      spec:
+        storageClassName: cephfs
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/apps/clubs/habitek/wordpress/base/deployment.yaml
+++ b/apps/clubs/habitek/wordpress/base/deployment.yaml
@@ -1,0 +1,108 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: habitek-wordpress
+  namespace: habitek
+  labels:
+    app: habitek
+  annotations:
+    kube-score/ignore: >-
+      pod-networkpolicy,
+      deployment-has-poddisruptionbudget,
+      container-security-context-readonlyrootfilesystem,
+      container-security-context-user-group-id
+spec:
+  selector:
+    matchLabels:
+      app: habitek
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: habitek
+        tier: frontend
+    spec:
+      containers:
+        - image: wordpress:6.9.4-php8.2-apache
+          imagePullPolicy: Always
+          name: habitek-wordpress
+          envFrom:
+            - secretRef:
+                name: habitek-secret
+          ports:
+            - containerPort: 80
+              name: http
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /wp-login.php
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: habitek-wordpress-persistent-storage
+              mountPath: /var/www/html
+            - name: php-config
+              mountPath: /usr/local/etc/php/conf.d/uploads.ini
+              subPath: uploads.ini
+          resources:
+            requests:
+              cpu: 2
+              memory: 1024Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 3
+              memory: 2048Mi
+              ephemeral-storage: 1Gi
+      volumes:
+        - name: habitek-wordpress-persistent-storage
+          persistentVolumeClaim:
+            claimName: habitek-wp-pv-claim
+        - name: php-config
+          configMap:
+            defaultMode: 420
+            name: wp-php-config
+      securityContext:
+        fsGroup: 33
+        runAsUser: 33
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: habitek-wp-pv-claim
+  namespace: habitek
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: cephfs
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wp-php-config
+data:
+  uploads.ini: |-
+    file_uploads = On
+    upload_max_filesize = 256M
+    post_max_size = 256M
+    memory_limit = 256M
+    max_execution_time = 600

--- a/apps/clubs/habitek/wordpress/base/kustomization.yaml
+++ b/apps/clubs/habitek/wordpress/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - db/statefulset.yaml
+  - db/service.yaml
+
+namespace: habitek

--- a/apps/clubs/habitek/wordpress/base/service.yaml
+++ b/apps/clubs/habitek/wordpress/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: habitek-svc
+spec:
+  selector:
+    app: habitek
+  ports:
+    - name: http
+      targetPort: 80
+      protocol: TCP
+      port: 80

--- a/apps/clubs/habitek/wordpress/habitek-wordpress.argoapp.yaml
+++ b/apps/clubs/habitek/wordpress/habitek-wordpress.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: habitek-wordpress
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: habitek
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/habitek/wordpress/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/habitek/wordpress/prod/ingress.yaml
+++ b/apps/clubs/habitek/wordpress/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: habitek-prod-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - habitek.ca
+      secretName: habitek-prod-tls
+  rules:
+    - host: habitek.ca
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: habitek-svc
+                port:
+                  number: 80

--- a/apps/clubs/habitek/wordpress/prod/kustomization.yaml
+++ b/apps/clubs/habitek/wordpress/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml
+  - staging-ingress.yaml
+
+namespace: habitek

--- a/apps/clubs/habitek/wordpress/prod/staging-ingress.yaml
+++ b/apps/clubs/habitek/wordpress/prod/staging-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: habitek-staging-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - habitek.prodv2.cedille.club
+      secretName: habitek-staging-tls
+  rules:
+    - host: habitek.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: habitek-svc
+                port:
+                  number: 80

--- a/apps/clubs/markets/base/backend-deployment.yaml
+++ b/apps/clubs/markets/base/backend-deployment.yaml
@@ -1,0 +1,103 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markets-backend
+  annotations:
+    kube-score/ignore: pod-networkpolicy, container-image-pull-policy,container-image-tag, container-security-context-user-group-id, container-security-context-privileged, container-security-context-readonlyrootfilesystem
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: markets-backend
+  template:
+    metadata:
+      labels:
+        app: markets-backend
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/algoets/markets-backend:latest
+          imagePullPolicy: Always
+          ports:
+            - containerPort: 8000
+          envFrom:
+            - secretRef:
+                name: markets-env-secret
+          env:
+            - name: GITHUB_BUG_REPORT_LABELS
+              valueFrom:
+                configMapKeyRef:
+                  name: markets-configmap
+                  key: GITHUB_BUG_REPORT_LABELS
+
+          # volumeMounts:
+          #   - name: logs-temp
+          #     mountPath: /app/markets/logs
+          #   - name: migrations-temp
+          #     mountPath: /app/markets/trading_system/migrations
+          resources:
+            requests:
+              cpu: "400m"
+              memory: "512Mi"
+            limits:
+              cpu: "800m"
+              memory: "1Gi"
+              ephemeral-storage: 1Gi
+          readinessProbe:
+            tcpSocket:
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          # securityContext:
+          #   runAsUser: 10001
+          #   runAsGroup: 10001
+          #   allowPrivilegeEscalation: true
+          #   readOnlyRootFilesystem: false
+          #   capabilities:
+          #     drop:
+          #       - ALL
+          #   seccompProfile:
+          #     type: RuntimeDefault
+      imagePullSecrets:
+        - name: ghcr-markets-secret
+      # volumes:
+      #   - name: logs-temp
+      #     emptyDir: {}
+      #   - name: migrations-temp
+      #     emptyDir: {}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markets-scheduler
+  annotations:
+    kube-score/ignore: pod-networkpolicy, container-image-pull-policy,container-image-tag,  container-security-context-user-group-id, container-security-context-privileged, container-security-context-readonlyrootfilesystem
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: markets-scheduler
+  template:
+    metadata:
+      labels:
+        app: markets-scheduler
+    spec:
+      containers:
+        - name: scheduler
+          image: ghcr.io/algoets/markets-scheduler:latest
+          imagePullPolicy: Always
+          envFrom:
+            - secretRef:
+                name: markets-env-secret
+          resources:
+            requests:
+              cpu: "300m"
+              memory: "512Mi"
+            limits:
+              cpu: "600m"
+              memory: "800Mi"
+              ephemeral-storage: 1Gi
+      imagePullSecrets:
+        - name: ghcr-markets-secret

--- a/apps/clubs/markets/base/backend-service.yaml
+++ b/apps/clubs/markets/base/backend-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: markets-backend-service
+spec:
+  selector:
+    app: markets-backend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+  type: ClusterIP

--- a/apps/clubs/markets/base/frontend-deployment.yaml
+++ b/apps/clubs/markets/base/frontend-deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markets-frontend
+  annotations:
+    kube-score/ignore: pod-networkpolicy, container-image-pull-policy,container-image-tag,  container-security-context-user-group-id, container-security-context-privileged, container-security-context-readonlyrootfilesystem
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: markets-frontend
+  template:
+    metadata:
+      labels:
+        app: markets-frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/algoets/markets-frontend:latest
+          ports:
+            - containerPort: 80
+          envFrom:
+            - secretRef:
+                name: markets-env-secret
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: "400m"
+              memory: "512Mi"
+            limits:
+              cpu: "800m"
+              memory: "1Gi"
+              ephemeral-storage: 1Gi
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          volumeMounts:
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: nginx-temp
+              mountPath: /var/run
+            - name: nginx-log
+              mountPath: /var/log/nginx
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-temp
+          emptyDir: {}
+        - name: nginx-log
+          emptyDir: {}
+      imagePullSecrets:
+        - name: ghcr-markets-secret

--- a/apps/clubs/markets/base/frontend-service.yaml
+++ b/apps/clubs/markets/base/frontend-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: markets-frontend-service
+spec:
+  selector:
+    app: markets-frontend
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+  type: ClusterIP

--- a/apps/clubs/markets/base/kustomization.yaml
+++ b/apps/clubs/markets/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - backend-deployment.yaml
+  - backend-service.yaml
+  - frontend-deployment.yaml
+  - frontend-service.yaml
+  - postgresql.yaml

--- a/apps/clubs/markets/base/postgresql.yaml
+++ b/apps/clubs/markets/base/postgresql.yaml
@@ -1,0 +1,43 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cnpg
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:17.2
+  instances: 1
+  bootstrap:
+    initdb:
+      database: markets
+      owner: markets
+      secret:
+        name: cnpg-secret
+  storage:
+    size: 5Gi
+    storageClass: cephfs
+  postgresql:
+    parameters:
+      max_connections: "200"
+      superuser_reserved_connections: "5"
+      statement_timeout: "30000"
+      idle_in_transaction_session_timeout: "30000"
+---
+apiVersion: postgresql.cnpg.io/v1
+kind: Pooler
+metadata:
+  name: markets-pooler-rw
+spec:
+  cluster:
+    name: cnpg
+  type: rw
+  instances: 1
+  pgbouncer:
+    poolMode: transaction
+    parameters:
+      max_client_conn: "2000"
+      default_pool_size: "10"
+      min_pool_size: "0"
+      reserve_pool_size: "5"
+      max_db_connections: "120"
+      query_wait_timeout: "5000"
+      server_idle_timeout: "300"
+      ignore_startup_parameters: "extra_float_digits,options"

--- a/apps/clubs/markets/dev/configMap.yaml
+++ b/apps/clubs/markets/dev/configMap.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: markets-configmap
+data:
+  GITHUB_BUG_REPORT_LABELS: "bug,bug-report,from-app,dev"

--- a/apps/clubs/markets/dev/ingress.yaml
+++ b/apps/clubs/markets/dev/ingress.yaml
@@ -1,0 +1,53 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: markets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - markets.dev.cedille.club
+      secretName: markets-tls
+  rules:
+    - host: markets.dev.cedille.club
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-frontend-service
+                port:
+                  number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /verification
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /static
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80

--- a/apps/clubs/markets/dev/kustomization.yaml
+++ b/apps/clubs/markets/dev/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml
+  - configMap.yaml
+
+patchesStrategicMerge:
+  - patch-backend-image.yaml
+  - patch-frontend-image.yaml

--- a/apps/clubs/markets/dev/patch-backend-image.yaml
+++ b/apps/clubs/markets/dev/patch-backend-image.yaml
@@ -1,0 +1,27 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markets-backend
+spec:
+  selector:
+    matchLabels:
+      app: markets-backend
+  template:
+    spec:
+      containers:
+        - name: backend
+          image: ghcr.io/algoets/markets-backend:dernier
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markets-scheduler
+spec:
+  selector:
+    matchLabels:
+      app: markets-scheduler
+  template:
+    spec:
+      containers:
+        - name: scheduler
+          image: ghcr.io/algoets/markets-scheduler:dernier

--- a/apps/clubs/markets/dev/patch-frontend-image.yaml
+++ b/apps/clubs/markets/dev/patch-frontend-image.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markets-frontend
+spec:
+  selector:
+    matchLabels:
+      app: markets-frontend
+  template:
+    spec:
+      containers:
+        - name: frontend
+          image: ghcr.io/algoets/markets-frontend:dernier

--- a/apps/clubs/markets/markets-shared.argoapp.yaml
+++ b/apps/clubs/markets/markets-shared.argoapp.yaml
@@ -1,0 +1,59 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: markets-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: backend=ghcr.io/algoets/markets-backend:latest,frontend=ghcr.io/algoets/markets-frontend:latest,scheduler=ghcr.io/algoets/markets-scheduler:latest
+    argocd-image-updater.argoproj.io/backend.update-strategy: digest
+    argocd-image-updater.argoproj.io/frontend.update-strategy: digest
+    argocd-image-updater.argoproj.io/scheduler.update-strategy: digest
+    argocd-image-updater.argoproj.io/backend.pull-secret: pullsecret:argocd/ghcr-markets-secret
+    argocd-image-updater.argoproj.io/frontend.pull-secret: pullsecret:argocd/ghcr-markets-secret
+    argocd-image-updater.argoproj.io/scheduler.pull-secret: pullsecret:argocd/ghcr-markets-secret
+spec:
+  project: algoets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: markets
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/markets/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: markets-dev-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: backend=ghcr.io/algoets/markets-backend:dernier,frontend=ghcr.io/algoets/markets-frontend:dernier,scheduler=ghcr.io/algoets/markets-scheduler:dernier
+    argocd-image-updater.argoproj.io/backend.update-strategy: digest
+    argocd-image-updater.argoproj.io/frontend.update-strategy: digest
+    argocd-image-updater.argoproj.io/scheduler.update-strategy: digest
+    argocd-image-updater.argoproj.io/backend.pull-secret: pullsecret:argocd/ghcr-markets-secret
+    argocd-image-updater.argoproj.io/frontend.pull-secret: pullsecret:argocd/ghcr-markets-secret
+    argocd-image-updater.argoproj.io/scheduler.pull-secret: pullsecret:argocd/ghcr-markets-secret
+spec:
+  project: algoets
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: markets-dev
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/markets/dev
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/markets/prod/configMap.yaml
+++ b/apps/clubs/markets/prod/configMap.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: markets-configmap
+data:
+  GITHUB_BUG_REPORT_LABELS: "bug,bug-report,from-app,prod"

--- a/apps/clubs/markets/prod/ingress-algoets.yaml
+++ b/apps/clubs/markets/prod/ingress-algoets.yaml
@@ -1,0 +1,53 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: markets-algoets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - markets.algoets.ca
+      secretName: markets-algoets-tls
+  rules:
+    - host: markets.algoets.ca
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-frontend-service
+                port:
+                  number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /verification
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /static
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80

--- a/apps/clubs/markets/prod/ingress.yaml
+++ b/apps/clubs/markets/prod/ingress.yaml
@@ -1,0 +1,53 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: markets-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - markets.prodv2.cedille.club
+      secretName: markets-tls
+  rules:
+    - host: markets.prodv2.cedille.club
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-frontend-service
+                port:
+                  number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /verification
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80
+          - path: /static
+            pathType: Prefix
+            backend:
+              service:
+                name: markets-backend-service
+                port:
+                  number: 80

--- a/apps/clubs/markets/prod/kustomization.yaml
+++ b/apps/clubs/markets/prod/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml
+  - ingress-algoets.yaml
+  - configMap.yaml
+  - vault-secret.yaml
+
+patches:
+  - path: patch-api-token-salt.yaml

--- a/apps/clubs/markets/prod/patch-api-token-salt.yaml
+++ b/apps/clubs/markets/prod/patch-api-token-salt.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markets-backend
+spec:
+  template:
+    spec:
+      containers:
+        - name: backend
+          env:
+            - name: API_TOKEN_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: markets-api-token-salt
+                  key: API_TOKEN_SALT
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: markets-scheduler
+spec:
+  template:
+    spec:
+      containers:
+        - name: scheduler
+          env:
+            - name: API_TOKEN_SALT
+              valueFrom:
+                secretKeyRef:
+                  name: markets-api-token-salt
+                  key: API_TOKEN_SALT

--- a/apps/clubs/markets/prod/vault-secret.yaml
+++ b/apps/clubs/markets/prod/vault-secret.yaml
@@ -1,0 +1,22 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: markets-api-token-salt
+spec:
+  refreshPeriod: 1h0m0s
+  refreshThreshold: 90
+  syncOnResourceChange: false
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: markets
+      path: kv/data/markets/default/config
+      requestType: GET
+  output:
+    name: markets-api-token-salt
+    stringData:
+      API_TOKEN_SALT: '{{ .markets.API_TOKEN_SALT }}'
+    type: opaque

--- a/apps/clubs/patchets/base/autoscaler.yaml
+++ b/apps/clubs/patchets/base/autoscaler.yaml
@@ -1,0 +1,12 @@
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: commandes
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: commandes
+  minReplicas: 2
+  maxReplicas: 4
+  targetCPUUtilizationPercentage: 75

--- a/apps/clubs/patchets/base/db/postgres.yaml
+++ b/apps/clubs/patchets/base/db/postgres.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgresql
+  namespace: patchets
+  annotations:
+    kube-score/ignore: >-
+      container-security-context-privileged,
+      container-security-context-user-group-id,
+      container-security-context-readonlyrootfilesystem,
+      container-image-pull-policy,
+      pod-probes,
+      container-resources,
+      container-ephemeral-storage-request-and-limit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgresql
+  template:
+    metadata:
+      labels:
+        app: postgresql
+    spec:
+      containers:
+        - name: postgresql
+          image: postgres:16.4
+          env:
+            - name: POSTGRES_USER
+              value: commandes_patchets_user
+            - name: POSTGRES_DB
+              value: commandes_patchets2
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: commandes-patchets-secret
+                  key: password
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+      volumes:
+        - name: postgres-data
+          persistentVolumeClaim:
+            claimName: postgres-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: postgres-pvc
+  namespace: patchets
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 4Gi
+  storageClassName: cephfs
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: commandes-db-postgresql
+  namespace: patchets
+spec:
+  type: ClusterIP
+  ports:
+    - port: 5432
+      targetPort: 5432
+      protocol: TCP
+  selector:
+    app: postgresql

--- a/apps/clubs/patchets/base/deployment.yaml
+++ b/apps/clubs/patchets/base/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: commandes
+  annotations:
+    kube-score/ignore: >-
+      container-image-tag,
+      container-security-context-user-group-id,
+      container-security-context-readonlyrootfilesystem
+spec:
+  selector:
+    matchLabels:
+      app: commandes
+  template:
+    metadata:
+      labels:
+        app: commandes
+    spec:
+      containers:
+        - name: commandes
+          image: ghcr.io/clubcedille/patchets-commande:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 3000
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command:
+                - bundle
+                - exec
+                - rails
+                - runner
+                - ActiveRecord::Base.connection.execute('SELECT 1'); puts 'ready'
+            initialDelaySeconds: 20
+            periodSeconds: 30
+            timeoutSeconds: 20
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - bundle
+                - exec
+                - rails
+                - runner
+                - ActiveRecord::Base.connection.execute('SELECT 1'); puts 'alive'
+            initialDelaySeconds: 120
+            periodSeconds: 60
+            timeoutSeconds: 20
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          envFrom:
+            - configMapRef:
+                name: commandes-config
+            - secretRef:
+                name: app-secrets
+      imagePullSecrets:
+        - name: patchets-pull

--- a/apps/clubs/patchets/base/kustomization.yaml
+++ b/apps/clubs/patchets/base/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: patchets
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - autoscaler.yaml
+  - pdb.yaml
+  - networkpolicy.yaml
+  - db/postgres.yaml
+  # - seeder.yaml # TODO: Uncomment when seeding is needed.
+
+configMapGenerator:
+  - name: commandes-config
+    literals:
+      - RAILS_ENV=production
+      - SQUARE_ENV=production
+      - DATABASE_PORT=5432
+
+images:
+  - name: us.gcr.io/fine-harbor-276700/patchets/commandes
+    newTag: 1.5.0

--- a/apps/clubs/patchets/base/networkpolicy.yaml
+++ b/apps/clubs/patchets/base/networkpolicy.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: commandes-allow-all
+spec:
+  podSelector:
+    matchLabels:
+      app: commandes
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: postgresql-allow-all
+spec:
+  podSelector:
+    matchLabels:
+      app: postgresql
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}

--- a/apps/clubs/patchets/base/pdb.yaml
+++ b/apps/clubs/patchets/base/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: commandes-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: commandes

--- a/apps/clubs/patchets/base/seeder.yaml
+++ b/apps/clubs/patchets/base/seeder.yaml
@@ -1,0 +1,29 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: commandes-seeder
+spec:
+  template:
+    spec:
+      containers:
+        - name: commandes-seeder
+          image: us.gcr.io/fine-harbor-276700/patchets/commandes:latest
+          command:
+            - bash
+            - -c
+            - rake db:schema:load && rake db:seed
+          ports:
+            - containerPort: 3000
+          resources: {}
+          env:
+            - name: DISABLE_DATABASE_ENVIRONMENT_CHECK
+              value: "1"
+          envFrom:
+            - configMapRef:
+                name: commandes-config
+            - secretRef:
+                name: app-secrets
+          imagePullPolicy: Always
+      restartPolicy: OnFailure
+      imagePullSecrets:
+        - name: gcrcedille-pull

--- a/apps/clubs/patchets/base/service.yaml
+++ b/apps/clubs/patchets/base/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: commandes
+spec:
+  ports:
+    - name: commandes
+      port: 3000
+      targetPort: http
+  selector:
+    app: commandes

--- a/apps/clubs/patchets/patchets-commande-shared.argoapp.yaml
+++ b/apps/clubs/patchets/patchets-commande-shared.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: patchets-commande-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: website=ghcr.io/clubcedille/patchets-commande:latest
+    argocd-image-updater.argoproj.io/website.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: patchets
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/patchets/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/patchets/prod/ingress.yaml
+++ b/apps/clubs/patchets/prod/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: commandes
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - commande.fraternitedupiranha.com
+      secretName: commande-cert-tls
+  rules:
+    - host: commande.fraternitedupiranha.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: commandes
+                port:
+                  number: 3000

--- a/apps/clubs/patchets/prod/kustomization.yaml
+++ b/apps/clubs/patchets/prod/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: patchets
+
+resources:
+  - ingress.yaml
+  - ../base

--- a/apps/clubs/penpot/helm/values.yaml
+++ b/apps/clubs/penpot/helm/values.yaml
@@ -1,0 +1,643 @@
+# yaml-language-server: $schema=values.schema.json
+## Default values for Penpot
+
+global:
+  postgresqlEnabled: false
+  # -- Whether to deploy the Bitnami Valkey chart as subchart. Check [the official chart](https://artifacthub.io/packages/helm/bitnami/valkey) for configuration.
+  # @section -- Global parameters
+  valkeyEnabled: true
+  redisEnabled: false
+  imagePullSecrets: []
+
+# -- To partially override common.names.fullname
+# @section -- Common parameters
+nameOverride: ""
+# -- To fully override common.names.fullname
+# @section -- Common parameters
+fullnameOverride: ""
+serviceAccount:
+  # -- Specifies whether a ServiceAccount should be created.
+  # @section -- Common parameters
+  enabled: true
+  # -- Annotations for service account. Evaluated as a template.
+  # @section -- Common parameters
+  annotations: {}
+  # -- The name of the ServiceAccount to use. If not set and enabled is true, a name is generated using the fullname template.
+  # @section -- Common parameters
+  name: "penpot"
+
+config:
+  # -- The public domain to serve Penpot on.
+  # **IMPORTANT:** Set `disable-secure-session-cookies` in the flags if you plan on serving it on a non HTTPS domain.
+  # @section -- Configuration parameters
+  publicUri: "http://penpot.prodv2.cedille.club"
+  # -- The feature flags to enable. Check [the official docs](https://help.penpot.app/technical-guide/configuration/) for more info.
+  # @section -- Configuration parameters
+  flags: "enable-registration enable-login-with-password disable-email-verification enable-smtp"
+  # @section -- Configuration parameters
+  # -- The name of an existing secret.
+  # @section -- Configuration parameters
+  existingSecret: "penpot-secret"
+  secretKeys:
+    # -- The api secret key to use from an existing secret.
+    # @section -- Configuration parameters
+    apiSecretKey: "apiKey"
+  # -- Comma separated list of allowed domains to register. Empty to allow all domains.
+  # @section -- Configuration parameters
+  registrationDomainWhitelist: ""
+  # -- Whether to enable sending of anonymous telemetry data.
+  # @section -- Configuration parameters
+  telemetryEnabled: true
+  # -- Add custom resolver for frontend. e.g. 192.168.1.1
+  # @section -- Configuration parameters
+  internalResolver: ""
+  # -- Url adress to Terms of Services (empty to hide the link)
+  # @section -- Configuration parameters
+  termsOfServicesUri: ""
+  # -- Url adress to Privacy Policy (empty to hide the link)
+  # @section -- Configuration parameters
+  privacyPolicyUri: ""
+
+  postgresql:
+    # -- The name of an existing secret.
+    # @section -- Configuration parameters
+    existingSecret: "penpot-secret"
+    secretKeys:
+      postgresqlUriKey: "uri"
+      passwordKey: "password"
+      usernameKey: "username"
+
+  objectsStorage:
+    # -- The storage backend for different objects (assets, old data...) to use. Use `fs` for filesystem, and `s3` for S3.
+    # @section -- Configuration parameters
+    storageBackend: "fs"
+    filesystem:
+      # -- The storage directory to use if you chose the filesystem storage backend.
+      # @section -- Configuration parameters
+      directory: "/opt/data/assets"
+
+  # -- Define the strategy (backend) for internal file data storage of Penpot. Use "legacy-db" (default) the current behaviour, "db" to use an specific table in the database (future default) and "storage" to use the predefined objects storage system (S3, file system,...)
+  # @section -- Configuration parameters
+  fileDataBackend: "legacy-db"
+
+  providers:
+    google:
+      # -- Whether to enable Google configuration. To enable Google auth, add `enable-login-with-google` to the flags.
+      # @section -- Configuration parameters
+      enabled: false
+      # -- The Google client ID to use. To enable Google auth, add `enable-login-with-google` to the flags.
+      # @section -- Configuration parameters
+      clientID: ""
+      # -- The Google client secret to use. To enable Google auth, add `enable-login-with-google` to the flags.
+      # @section -- Configuration parameters
+      clientSecret: ""
+    github:
+      # -- Whether to enable GitHub configuration. To enable GitHub auth, also add `enable-login-with-github` to the flags.
+      # @section -- Configuration parameters
+      enabled: false
+      # -- The GitHub client ID to use.
+      # @section -- Configuration parameters
+      clientID: ""
+      # -- The GitHub client secret to use.
+      # @section -- Configuration parameters
+      clientSecret: ""
+    gitlab:
+      # -- Whether to enable GitLab configuration. To enable GitLab auth, also add `enable-login-with-gitlab` to the flags.
+      # @section -- Configuration parameters
+      enabled: false
+      # -- The GitLab base URI to use.
+      # @section -- Configuration parameters
+      baseURI: "https://gitlab.com"
+      # -- The GitLab client ID to use.
+      # @section -- Configuration parameters
+      clientID: ""
+      # -- The GitLab client secret to use.
+      # @section -- Configuration parameters
+      clientSecret: ""
+    oidc:
+      # -- Whether to enable OIDC configuration. To enable OpenID Connect auth, also add `enable-login-with-oidc` to the flags.
+      # @section -- Configuration parameters
+      enabled: false
+      # -- The OpenID Connect base URI to use.
+      # @section -- Configuration parameters
+      baseURI: ""
+      # -- The OpenID Connect client ID to use.
+      # @section -- Configuration parameters
+      clientID: ""
+      # -- The OpenID Connect client secret to use.
+      # @section -- Configuration parameters
+      clientSecret: ""
+      # -- Optional OpenID Connect auth URI to use. Auto discovered if not provided.
+      # @section -- Configuration parameters
+      authURI: ""
+      # -- Optional OpenID Connect token URI to use. Auto discovered if not provided.
+      # @section -- Configuration parameters
+      tokenURI: ""
+      # -- Optional OpenID Connect user URI to use. Auto discovered if not provided.
+      # @section -- Configuration parameters
+      userURI: ""
+      # -- Optional OpenID Connect roles to use. If no role is provided, role checking is  disabled (default role values are set below, to disable role verification, send an empty string).
+      # @section -- Configuration parameters
+      roles: "designer developer"
+      # -- Optional OpenID Connect roles attribute to use. If not provided, the role checking will be disabled.
+      # @section -- Configuration parameters
+      rolesAttribute: ""
+      # -- Optional OpenID Connect scopes to use. These settings allow overwriting the required scopes, use with caution because penpot requires at least `name` and `email` attrs found on the user info. Optional, defaults to `openid profile`.
+      # @section -- Configuration parameters
+      scopes: "scope1 scope2"
+      # -- Optional OpenID Connect name attribute to use. If not provided, the `name` prop will be used.
+      # @section -- Configuration parameters
+      nameAttribute: ""
+      # -- Optional OpenID Connect email attribute to use. If not provided, the `email` prop will be used.
+      # @section -- Configuration parameters
+      emailAttribute: ""
+    ldap:
+      # -- Whether to enable LDAP configuration. To enable LDAP, also add `enable-login-with-ldap` to the flags.
+      # @section -- Configuration parameters
+      enabled: false
+      # -- The LDAP host to use.
+      # @section -- Configuration parameters
+      host: "ldap"
+      # -- The LDAP port to use.
+      # @section -- Configuration parameters
+      port: 10389
+      # -- Whether to use SSL for the LDAP connection.
+      # @section -- Configuration parameters
+      ssl: false
+      # -- Whether to utilize StartTLS for the LDAP connection.
+      # @section -- Configuration parameters
+      startTLS: false
+      # -- The LDAP base DN to use.
+      # @section -- Configuration parameters
+      baseDN: "ou=people,dc=planetexpress,dc=com"
+      # -- The LDAP bind DN to use.
+      # @section -- Configuration parameters
+      bindDN: "uid=admin,ou=people,dc=planetexpress,dc=com"
+      # -- The LDAP bind password to use.
+      # @section -- Configuration parameters
+      bindPassword: "GoodNewsEveryone"
+      # -- The LDAP user query to use.
+      # @section -- Configuration parameters
+      userQuery: "(&(|(uid=:username)(mail=:username))(memberOf=cn=penpot,ou=groups,dc=my-domain,dc=com))"
+      # -- The LDAP attributes username to use.
+      # @section -- Configuration parameters
+      attributesUsername: "uid"
+      # -- The LDAP attributes email to use.
+      # @section -- Configuration parameters
+      attributesEmail: "mail"
+      # -- The LDAP attributes fullname to use.
+      # @section -- Configuration parameters
+      attributesFullname: "cn"
+      # -- The LDAP attributes photo format to use.
+      # @section -- Configuration parameters
+      attributesPhoto: "jpegPhoto"
+    # -- The name of an existing secret to use.
+    # @section -- Configuration parameters
+    existingSecret: ""
+    secretKeys:
+      # -- The Google client ID key to use from an existing secret.
+      # @section -- Configuration parameters
+      googleClientIDKey: ""
+      # -- The Google client secret key to use from an existing secret.
+      # @section -- Configuration parameters
+      googleClientSecretKey: ""
+      # -- The GitHub client ID key to use from an existing secret.
+      # @section -- Configuration parameters
+      githubClientIDKey: ""
+      # -- The GitHub client secret key to use from an existing secret.
+      # @section -- Configuration parameters
+      githubClientSecretKey: ""
+      # -- The GitLab client ID key to use from an existing secret.
+      # @section -- Configuration parameters
+      gitlabClientIDKey: ""
+      # -- The GitLab client secret key to use from an existing secret.
+      # @section -- Configuration parameters
+      gitlabClientSecretKey: ""
+      # -- The OpenID Connect client ID key to use from an existing secret.
+      # @section -- Configuration parameters
+      oidcClientIDKey: ""
+      # -- The OpenID Connect client secret key to use from an existing secret.
+      # @section -- Configuration parameters
+      oidcClientSecretKey: ""
+      # -- The LDAP admin bind password to use from an exsiting secret
+      # @section -- Configuration parameters
+      ldapBindPasswordKey: ""
+
+  autoFileSnapshot:
+    # -- How many changes before generating a new snapshot. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.
+    # @section -- Configuration parameters
+    every: 5 # Every 5 changes
+    # -- If there isn't a snapshot during this time, the system will generate one automatically. You also need to add the 'auto-file-snapshot' flag to the PENPOT_FLAGS variable.
+    # @section -- Configuration parameters
+    timeout: "3h"
+
+  # -- Specify any additional environment values you want to provide to all the containers (frontend, backend and exporter) in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
+  # @section -- Configuration parameters
+  extraEnvs: []
+
+backend:
+  image:
+    # -- The Docker repository to pull the image from.
+    # @section -- Backend parameters
+    repository: penpotapp/backend
+    # -- The image tag to use.
+    # @section -- Backend parameters
+    tag: 2.11.0
+    # -- The image pull policy to use.
+    # @section -- Backend parameters
+    pullPolicy: Always
+  # -- The number of replicas to deploy.
+  # @section -- Backend parameters
+  replicaCount: 1
+  service:
+    # -- The http service type to create.
+    # @section -- Backend parameters
+    type: ClusterIP
+    # -- The http service port to use.
+    # @section -- Backend parameters
+    port: 6060
+    # -- Mapped annotations for the backend service
+    # @section -- Backend parameters
+    annotations: {}
+  # -- An optional map of annotations to be applied to the controller Deployment
+  # @section -- Backend parameters
+  deploymentAnnotations: {}
+  # -- An optional map of labels to be applied to the controller Pods
+  # @section -- Backend parameters
+  podLabels: {}
+  # -- An optional map of annotations to be applied to the controller Pods
+  # @section -- Backend parameters
+  podAnnotations: {}
+  # -- Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  # @section -- Backend parameters
+  podSecurityContext:
+    fsGroup: 1001
+  # -- Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  # @section -- Backend parameters
+  containerSecurityContext:
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - all
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+  # -- Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+  # @section -- Backend parameters
+  affinity: {}
+  # -- Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/)
+  # @section -- Backend parameters
+  nodeSelector: {}
+  # -- Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+  # @section -- Backend parameters
+  tolerations: []
+  # -- Penpot backend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)
+  # @section -- Backend parameters
+  resources:
+    # -- The resources limits for the Penpot backend containers
+    # @section -- Backend parameters
+    limits: {}
+    # -- The requested resources for the Penpot backend containers
+    # @section -- Backend parameters
+    requests: {}
+  # -- Startup probe for the Penpot backend containers. Tolerates up to 30 * 10 = 300 seconds = 5 Minutes. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes)
+  # @section -- Backend parameters
+  startupProbe:
+    httpGet:
+      path: /readyz
+      port: http
+    failureThreshold: 30
+    periodSeconds: 10
+  # -- Configure Pod Disruption Budget for the backend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+  # @section -- Backend parameters
+  pdb:
+    # -- Enable Pod Disruption Budget for the backend pods.
+    # @section -- Backend parameters
+    enabled: false
+    # -- (int,string) The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%").
+    # @section -- Backend parameters
+    minAvailable:
+    # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
+    # @section -- Backend parameters
+    maxUnavailable:
+  # -- Specify any additional environment values you want to provide to the backend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
+  # @section -- Backend parameters
+  extraEnvs: []
+  # -- Extra volumes to be made available. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # @section -- Backend parameters
+  volumes: []
+  # -- Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # @section -- Backend parameters
+  volumeMounts: []
+
+frontend:
+  image:
+    # -- The Docker repository to pull the image from.
+    # @section -- Frontend parameters
+    repository: penpotapp/frontend
+    # -- The image tag to use.
+    # @section -- Frontend parameters
+    tag: 2.11.0
+    # -- The image pull policy to use.
+    # @section -- Frontend parameters
+    pullPolicy: Always
+  # -- The number of replicas to deploy.
+  # @section -- Frontend parameters
+  replicaCount: 1
+  service:
+    # -- The service type to create.
+    # @section -- Frontend parameters
+    type: ClusterIP
+    # -- The service port to use.
+    # @section -- Frontend parameters
+    port: 8080
+    # -- Mapped annotations for the frontend service
+    # @section -- Frontend parameters
+    annotations: {}
+  # -- An optional map of annotations to be applied to the controller Deployment
+  # @section -- Frontend parameters
+  deploymentAnnotations: {}
+  # -- An optional map of labels to be applied to the controller Pods
+  # @section -- Frontend parameters
+  podLabels: {}
+  # -- An optional map of annotations to be applied to the controller Pods
+  # @section -- Frontend parameters
+  podAnnotations: {}
+  # -- Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  # @section -- Frontend parameters
+  podSecurityContext:
+    fsGroup: 1001
+  # -- Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  # @section -- Frontend parameters
+  containerSecurityContext:
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - all
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+  # -- Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+  # @section -- Frontend parameters
+  affinity: {}
+  # -- Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/)
+  # @section -- Frontend parameters
+  nodeSelector: {}
+  # -- Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+  # @section -- Frontend parameters
+  tolerations: []
+  # -- Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)
+  # @section -- Frontend parameters
+  resources:
+    # -- The resources limits for the Penpot frontend containers
+    # @section -- Frontend parameters
+    limits: {}
+    # -- The requested resources for the Penpot frontend containers
+    # @section -- Frontend parameters
+    requests: {}
+  # -- Configure Pod Disruption Budget for the frontend pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+  # @section -- Frontend parameters
+  pdb:
+    # -- Enable Pod Disruption Budget for the frontend pods.
+    # @section -- Frontend parameters
+    enabled: false
+    # -- (int,string) The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%").
+    # @section -- Frontend parameters
+    minAvailable:
+    # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
+    # @section -- Frontend parameters
+    maxUnavailable:
+  # -- Specify any additional environment values you want to provide to the frontend container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
+  # @section -- Frontend parameters
+  extraEnvs: []
+  # -- Extra volumes to be made available. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # @section -- Frontend parameters
+  volumes: []
+  # -- Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # @section -- Frontend parameters
+  volumeMounts: []
+
+exporter:
+  image:
+    # -- The Docker repository to pull the image from.
+    # @section -- Exporter parameters
+    repository: penpotapp/exporter
+    # -- The image tag to use.
+    # @section -- Exporter parameters
+    tag: 2.11.0
+    # -- The image pull policy to use.
+    # @section -- Exporter parameters
+    imagePullPolicy: Always
+  # -- The number of replicas to deploy. Enable persistence.exporter if you use more than 1 replicaCount
+  # @section -- Exporter parameters
+  replicaCount: 1
+  service:
+    # -- The service type to create.
+    # @section -- Exporter parameters
+    type: ClusterIP
+    # -- The service port to use.
+    # @section -- Exporter parameters
+    port: 6061
+    # -- Mapped annotations for the exporter service
+    # @section -- Exporter parameters
+    annotations: {}
+  # -- An optional map of annotations to be applied to the controller Deployment
+  # @section -- Exporter parameters
+  deploymentAnnotations: {}
+  # -- An optional map of labels to be applied to the controller Pods
+  # @section -- Exporter parameters
+  podLabels: {}
+  # -- An optional map of annotations to be applied to the controller Pods
+  # @section -- Exporter parameters
+  podAnnotations: {}
+  # -- Configure Pods Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  # @section -- Exporter parameters
+  podSecurityContext:
+    fsGroup: 1001
+  # -- Configure Container Security Context. Check [the official doc](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod)
+  # @section -- Exporter parameters
+  containerSecurityContext:
+    runAsUser: 1001
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - all
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+  # -- Affinity for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity)
+  # @section -- Exporter parameters
+  affinity: {}
+  # -- Node labels for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/user-guide/node-selection/)
+  # @section -- Exporter parameters
+  nodeSelector: {}
+  # -- Tolerations for Penpot pods assignment. Check [the official doc](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
+  # @section -- Exporter parameters
+  tolerations: []
+  # -- Penpot frontend resource requests and limits. Check [the official doc](https://kubernetes.io/docs/user-guide/compute-resources/)
+  # @section -- Exporter parameters
+  resources:
+    # -- The resources limits for the Penpot frontend containers
+    # @section -- Exporter parameters
+    limits: {}
+    # -- The requested resources for the Penpot frontend containers
+    # @section -- Exporter parameters
+    requests: {}
+  # -- Configure Pod Disruption Budget for the exporter pods. Check [the official doc](https://kubernetes.io/docs/tasks/run-application/configure-pdb/)
+  # @section -- Exporter parameters
+  pdb:
+    # -- Enable Pod Disruption Budget for the exporter pods.
+    # @section -- Exporter parameters
+    enabled: false
+    # -- (int,string) The number or percentage of pods from that set that must still be available after the eviction (e.g.: 3, "10%").
+    # @section -- Exporter parameters
+    minAvailable:
+    # -- (int,string) The number or percentage of pods from that set that can be unavailable after the eviction (e.g.: 3, "10%").
+    # @section -- Exporter parameters
+    maxUnavailable:
+  # -- Specify any additional environment values you want to provide to the exporter container in the deployment according to the [specification](https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/pod-v1/#environment-variables)
+  # @section -- Exporter parameters
+  extraEnvs: []
+  # -- Extra volumes to be made available. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # @section -- Exporter parameters
+  volumes: []
+  # -- Extra volumes to be mounted in the countainer. Check [the official doc](https://kubernetes.io/docs/concepts/storage/volumes/)
+  # @section -- Exporter parameters
+  volumeMounts: []
+
+persistence:
+  assets:
+    # -- Enable Penpot objects persistence using Persistent Volume Claims.
+    # @section -- Persistence parameters
+    enabled: true
+    # -- Penpot objects persistent Volume storage class.
+    # If defined, storageClassName: <storageClass>.
+    # If undefined (the default) or set to null, no storageClassName spec is set, choosing the default provisioner.
+    # @section -- Persistence parameters
+    storageClass: ""
+    # -- Penpot objects persistent Volume size.
+    # @section -- Persistence parameters
+    size: 20Gi
+    # -- The name of an existing PVC to use for Penpot objects persistence.
+    # @section -- Persistence parameters
+    existingClaim: ""
+    # -- Penpot objects persistent Volume access modes.
+    # @section -- Persistence parameters
+    accessModes:
+      - ReadWriteMany
+    # -- Penpot objects persistent Volume Claim annotations.
+    # @section -- Persistence parameters
+    annotations: {}
+
+  exporter:
+    # -- Enable exporter persistence using Persistent Volume Claims. If exporter.replicaCount you have to enable it.
+    # @section -- Persistence parameters
+    enabled: false
+    # -- Exporter persistent Volume storage class. Empty is choosing the default provisioner by the provider.
+    # @section -- Persistence parameters
+    storageClass: ""
+    # -- Exporter persistent Volume size.
+    # @section -- Persistence parameters
+    size: 10Gi
+    # -- The name of an existing PVC to use for persistence.
+    # @section -- Persistence parameters
+    existingClaim: ""
+    # -- Exporter persistent Volume access modes.
+    # @section -- Persistence parameters
+    accessModes:
+      - ReadWriteMany
+    # -- Exporter persistent Volume Claim annotations.
+    # @section -- Persistence parameters
+    annotations: {}
+
+ingress:
+  # -- Enable (frontend) Ingress Controller.
+  # @section -- Ingress parameters
+  enabled: false
+  # -- The Ingress className.
+  # @section -- Ingress parameters
+  className: ""
+  # -- Mapped annotations for the ingress crontroller.
+  # E.g.
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
+  # @section -- Ingress parameters
+  annotations: {}
+  # -- Root path for every hosts.
+  # @section -- Ingress parameters
+  path: "/"
+  # -- Array style hosts for the (frontend) ingress crontroller.
+  # @section -- Ingress parameters
+  hosts:
+    # -- The default external hostname to access to the penpot app.
+    # @section -- Ingress parameters
+    - "penpot.example.com"
+  # -- Array style TLS secrets for the (frontend) ingress crontroller.
+  # E.g.
+  # tls:
+  #   - secretName: penpot.example.com-tls
+  #     hosts:
+  #       - penpot.example.com
+  # @section -- Ingress parameters
+  tls: []
+
+route:
+  # -- Enable Openshift/OKD Route. Check [the official doc](https://docs.openshift.com/container-platform/4.16/networking/routes/route-configuration.html). When it is enabled, all fsGroup and runAsUser must be changed to null.
+  # @section -- Route parameters
+  enabled: false
+  # -- An optional map of annotations to be applied to the route.
+  # @section -- Route parameters
+  annotations: {}
+  # -- The default external hostname to access to the penpot app.
+  # @section -- Route parameters
+  host: penpot.example.com
+  # -- Define a path to use Path-based routes.
+  # @section -- Route parameters
+  path: null
+  # -- A Map with TLS configuration for the route.
+  # E.g.
+  # tls:
+  #   terminationType: edge
+  #   terminationPolicy: Redirect
+  # @section -- Route parameters
+  tls: {}
+  # -- Define the wildcard policy (None, Subdomain, ...)
+  # @section -- Route parameters
+  wildcardPolicy: None
+
+# Valkey configuration (Check for [more parameters here](https://artifacthub.io/packages/helm/bitnami/valkey))
+valkey:
+  image:
+    repository: bitnamilegacy/valkey
+    tag: "8.1.3-debian-12-r3"
+  global:
+    compatibility:
+      openshift:
+        # -- Adapt the securityContext sections of the deployment to make them compatible with Openshift restricted-v2 SCC: remove runAsUser, runAsGroup and fsGroup and let the platform use their allowed default IDs. Possible values: auto (apply if the detected running cluster is Openshift), force (perform the adaptation always), disabled (do not perform adaptation)
+        # @section -- Valkey Dependencie parameters
+        adaptSecurityContext: "auto"
+  auth:
+    # -- Whether to enable password authentication.
+    # @section -- Valkey Dependencie parameters
+    enabled: false
+  # -- Valkey architecture. Allowed values: `standalone` or `replication`. Penpot only needs a standalone Valkey StatefulSet. Check for [more info here](https://artifacthub.io/packages/helm/bitnami/vlakey#cluster-topologies)
+  # @section -- Valkey Dependencie parameters
+  architecture: standalone
+  # -- Common configuration to be appended to valkey.conf (as a block of configuration lines).
+  # @section -- Valkey Dependencie parameters
+  commonConfiguration: |
+    ## Recommended values for most Penpot instances.
+    ## You can modify this value to follow your policies.
+
+    # Set maximum memory Valkey will use.
+    # Accepted units: b, k, kb, m, mb, g, gb
+    maxmemory 128mb
+
+    # Choose an eviction policy (see Valkey docs:
+    # https://valkey.io/topics/memory-optimization/)
+    # Common choices:
+    #   noeviction, allkeys-lru, volatile-lru, allkeys-random, volatile-random,
+    #   volatile-ttl, volatile-lfu, allkeys-lfu
+    #
+    # For Penpot, volatile-lfu is recommended
+    maxmemory-policy volatile-lfu

--- a/apps/clubs/penpot/kustomization.yaml
+++ b/apps/clubs/penpot/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: penpot
+  namespace: penpot
+resources:
+  - prod/cnpg.yaml
+  - prod/ingress.yaml
+helmCharts:
+  - name: penpot
+    version: "0.29.0"
+    repo: "https://helm.penpot.app/"
+    releaseName: "penpot"
+    namespace: penpot
+    valuesFile: "helm/values.yaml"

--- a/apps/clubs/penpot/penpot-shared.argoapp.yaml
+++ b/apps/clubs/penpot/penpot-shared.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: penpot-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: penpot
+  source:
+    path: apps/clubs/penpot
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: false
+      selfHeal: false
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/clubs/penpot/prod/cnpg.yaml
+++ b/apps/clubs/penpot/prod/cnpg.yaml
@@ -1,0 +1,24 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: cnpg
+spec:
+  instances: 1
+
+  bootstrap:
+    initdb:
+      database: penpot
+      owner: penpot
+      secret:
+        name: penpot-secret
+
+  storage:
+    size: 5Gi
+    storageClass: "cephfs"
+  # Quelques paramètres de QOL
+  postgresql:
+    parameters:
+      max_connections: "200"
+      superuser_reserved_connections: "5"
+      statement_timeout: "30000"
+      idle_in_transaction_session_timeout: "30000"

--- a/apps/clubs/penpot/prod/ingress.yaml
+++ b/apps/clubs/penpot/prod/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: penpot
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - penpot.prodv2.cedille.club
+      secretName: penpot-cert-tls
+  rules:
+    - host: penpot.prodv2.cedille.club
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: penpot
+                port:
+                  number: 8080

--- a/apps/clubs/preci/wordpress/base/db/service.yaml
+++ b/apps/clubs/preci/wordpress/base/db/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - port: 3306
+  clusterIP: None

--- a/apps/clubs/preci/wordpress/base/db/statefulset.yaml
+++ b/apps/clubs/preci/wordpress/base/db/statefulset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  annotations:
+    kube-score/ignore: >-
+      container-image-tag,
+      container-ephemeral-storage-request-and-limit,
+      container-security-context-readonlyrootfilesystem,
+      container-security-context-user-group-id
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: mysql
+          image: mysql:latest
+          ports:
+            - containerPort: 3306
+              name: mysql
+          readinessProbe:
+            tcpSocket:
+              port: mysql
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          env:
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: preci-secret
+                  key: MYSQL_USER
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: preci-secret
+                  key: MYSQL_PASSWORD
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: preci-secret
+                  key: MYSQL_DATABASE
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: preci-secret
+                  key: MYSQL_ROOT_PASSWORD
+          volumeMounts:
+            - name: mysql-pv-claim
+              mountPath: /var/lib/mysql
+          resources:
+            requests:
+              cpu: 500m
+              memory: 512Mi
+            limits:
+              cpu: "1"
+              memory: 2Gi
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-pv-claim
+      spec:
+        storageClassName: cephfs
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/apps/clubs/preci/wordpress/base/deployment.yaml
+++ b/apps/clubs/preci/wordpress/base/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: preci-wordpress
+  namespace: preci
+  labels:
+    app: preci
+  annotations:
+    kube-score/ignore: >-
+      container-security-context-privileged,
+      container-security-context-user-group-id,
+      container-security-context-readonlyrootfilesystem
+spec:
+  selector:
+    matchLabels:
+      app: preci
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: preci
+        tier: frontend
+    spec:
+      containers:
+        - image: wordpress:php7.4-apache
+          imagePullPolicy: Always
+          name: preci-wordpress
+          envFrom:
+            - secretRef:
+                name: preci-secret
+          ports:
+            - name: http
+              containerPort: 80
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: preci-wordpress-persistent-storage
+              mountPath: /var/www/html
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: "1"
+              memory: 1Gi
+              ephemeral-storage: 1Gi
+      volumes:
+        - name: preci-wordpress-persistent-storage
+          persistentVolumeClaim:
+            claimName: preci-wp-pv-claim
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: preci-wordpress-pdb
+  namespace: preci
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: preci
+      tier: frontend
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: preci-wp-pv-claim
+  namespace: preci
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: cephfs

--- a/apps/clubs/preci/wordpress/base/kustomization.yaml
+++ b/apps/clubs/preci/wordpress/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - network.yaml
+  - networkpolicy.yaml
+  - db/statefulset.yaml
+  - db/service.yaml
+
+namespace: preci

--- a/apps/clubs/preci/wordpress/base/network.yaml
+++ b/apps/clubs/preci/wordpress/base/network.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: preci-wordpress
+  namespace: preci
+  labels:
+    app: preci
+spec:
+  ports:
+    - name: http
+      targetPort: 80
+      protocol: TCP
+      port: 80
+  type: ClusterIP
+  selector:
+    app: preci
+    tier: frontend

--- a/apps/clubs/preci/wordpress/base/networkpolicy.yaml
+++ b/apps/clubs/preci/wordpress/base/networkpolicy.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: preci-wordpress-allow-all
+  namespace: preci
+spec:
+  podSelector:
+    matchLabels:
+      app: preci
+      tier: frontend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: preci-mysql-allow-all
+  namespace: preci
+spec:
+  podSelector:
+    matchLabels:
+      app: mysql
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}

--- a/apps/clubs/preci/wordpress/preci-wordpress.argoapp.yaml
+++ b/apps/clubs/preci/wordpress/preci-wordpress.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: preci-wordpress
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: preci
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/preci/wordpress/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/preci/wordpress/prod/ingress.yaml
+++ b/apps/clubs/preci/wordpress/prod/ingress.yaml
@@ -1,0 +1,34 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: wordpress
+  namespace: preci
+spec:
+  virtualhost:
+    fqdn: preci.etsmtl.ca
+    tls:
+      secretName: tls-preci
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: preci-wordpress
+          port: 80
+      requestHeadersPolicy:
+        set:
+          - name: X-Forwarded-Proto
+            value: https
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-preci
+  namespace: preci
+spec:
+  secretName: tls-preci
+  issuerRef:
+    name: letsencrypt-http
+    kind: ClusterIssuer
+  commonName: preci.etsmtl.ca
+  dnsNames:
+    - preci.etsmtl.ca

--- a/apps/clubs/preci/wordpress/prod/kustomization.yaml
+++ b/apps/clubs/preci/wordpress/prod/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml
+
+namespace: preci

--- a/apps/clubs/trema/base/db/deployment.yaml
+++ b/apps/clubs/trema/base/db/deployment.yaml
@@ -1,0 +1,55 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mongo
+  annotations:
+    kube-score/ignore: pod-networkpolicy
+spec:
+  serviceName: mongo
+  selector:
+    matchLabels:
+      app: mongo
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: mongo
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:8.0.0
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+              ephemeral-storage: 256Mi
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+              ephemeral-storage: 1Gi
+          env:
+            - name: MONGO_INITDB_ROOT_USERNAME
+              value: "trema"
+            - name: MONGO_INITDB_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: trema-env-secret
+                  key: mongo_password
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: storage
+              mountPath: /data/db
+          livenessProbe:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            timeoutSeconds: 5
+            failureThreshold: 5
+      volumes:
+        - name: storage
+          persistentVolumeClaim:
+            claimName: mongo-pvc

--- a/apps/clubs/trema/base/db/network.yaml
+++ b/apps/clubs/trema/base/db/network.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+spec:
+  clusterIP: None
+  selector:
+    app: mongo
+  ports:
+    - port: 27017
+      targetPort: 27017

--- a/apps/clubs/trema/base/db/pvc.yaml
+++ b/apps/clubs/trema/base/db/pvc.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongo-pvc
+spec:
+  storageClassName: cephfs
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "10Gi"

--- a/apps/clubs/trema/base/deployment.yaml
+++ b/apps/clubs/trema/base/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: trema
+  annotations:
+    kube-score/ignore: container-image-tag, pod-networkpolicy
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: trema
+  template:
+    metadata:
+      labels:
+        app: trema
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+        prometheus.io/path: /metrics
+    spec:
+      containers:
+        - name: trema
+          image: ghcr.io/clubcedille/trema:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              memory: "512Mi"
+              cpu: "500m"
+              ephemeral-storage: 256Mi
+            limits:
+              memory: "1Gi"
+              cpu: "1"
+              ephemeral-storage: 1Gi
+          ports:
+            - containerPort: 6000
+            - name: metrics
+              containerPort: 9090
+          readinessProbe:
+            exec:
+              command:
+                - python
+                - /app/scripts/check_db.py
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          env:
+            - name: API_ADDRESS
+              value: "0.0.0.0"
+            - name: API_PORT
+              value: "6000"
+            - name: MONGO_HOST
+              value: "mongo.trema.svc.cluster.local"
+            - name: MONGO_USER
+              value: "trema"
+            - name: MONGO_PORT
+              value: "27017"
+            - name: MONGO_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: trema-env-secret
+                  key: mongo_password
+            - name: DISCORD_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: trema-env-secret
+                  key: discord_token
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: trema-env-secret
+                  key: github_token
+            - name: CALIDUM_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: trema-env-secret
+                  key: calidum_api_key

--- a/apps/clubs/trema/base/kustomization.yaml
+++ b/apps/clubs/trema/base/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - network.yaml
+  - deployment.yaml
+  - db/deployment.yaml
+  - db/network.yaml
+  - db/pvc.yaml

--- a/apps/clubs/trema/base/network.yaml
+++ b/apps/clubs/trema/base/network.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: trema
+spec:
+  selector:
+    app: trema
+  ports:
+    - name: http
+      targetPort: 6000
+      protocol: TCP
+      port: 80
+    - name: metrics
+      port: 9090
+      targetPort: 9090
+  type: ClusterIP

--- a/apps/clubs/trema/prod/ingress.yaml
+++ b/apps/clubs/trema/prod/ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: trema-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+    gatus.cedille/protocol: "tcp"
+spec:
+  ingressClassName: contour
+  tls:
+    - secretName: trema-tls
+      hosts:
+        - trema.prodv2.cedille.club
+  rules:
+    - host: trema.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: trema
+                port:
+                  name: http

--- a/apps/clubs/trema/prod/kustomization.yaml
+++ b/apps/clubs/trema/prod/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml

--- a/apps/clubs/trema/trema-shared.argoapp.yaml
+++ b/apps/clubs/trema/trema-shared.argoapp.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trema-shared
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+    argocd-image-updater.argoproj.io/image-list: trema=ghcr.io/clubcedille/trema:latest
+    argocd-image-updater.argoproj.io/trema.update-strategy: digest
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: trema
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/trema/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/apps/clubs/veloom/wordpress/base/db/service.yaml
+++ b/apps/clubs/veloom/wordpress/base/db/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+spec:
+  selector:
+    app: mysql
+  ports:
+    - port: 3306
+  clusterIP: None

--- a/apps/clubs/veloom/wordpress/base/db/statefulset.yaml
+++ b/apps/clubs/veloom/wordpress/base/db/statefulset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql
+  annotations:
+    kube-score/ignore: >-
+      container-image-pull-policy,
+      container-ephemeral-storage-request-and-limit,
+      container-security-context-readonlyrootfilesystem,
+      container-security-context-user-group-id
+spec:
+  serviceName: mysql
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      securityContext:
+        fsGroup: 999
+      containers:
+        - name: mysql
+          image: mysql:9.6.0
+          ports:
+            - containerPort: 3306
+              name: mysql
+          readinessProbe:
+            tcpSocket:
+              port: mysql
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 6
+          env:
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: veloom-secret
+                  key: MYSQL_USER
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: veloom-secret
+                  key: MYSQL_PASSWORD
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: veloom-secret
+                  key: MYSQL_DATABASE
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: veloom-secret
+                  key: MYSQL_ROOT_PASSWORD
+          volumeMounts:
+            - name: mysql-pv-claim
+              mountPath: /var/lib/mysql
+          resources:
+            requests:
+              cpu: 300m
+              memory: 512Mi
+            limits:
+              cpu: 500m
+              memory: 1Gi
+          securityContext:
+            runAsUser: 999
+            runAsGroup: 999
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+  volumeClaimTemplates:
+    - metadata:
+        name: mysql-pv-claim
+      spec:
+        storageClassName: cephfs
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/apps/clubs/veloom/wordpress/base/deployment.yaml
+++ b/apps/clubs/veloom/wordpress/base/deployment.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: veloom-wordpress
+  namespace: veloom
+  labels:
+    app: veloom
+  annotations:
+    kube-score/ignore: >-
+      container-security-context-privileged,
+      container-security-context-user-group-id,
+      container-security-context-readonlyrootfilesystem
+spec:
+  selector:
+    matchLabels:
+      app: veloom
+      tier: frontend
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: veloom
+        tier: frontend
+    spec:
+      containers:
+        - image: wordpress:6.8.3-php8.1-apache
+          imagePullPolicy: Always
+          name: veloom-wordpress
+          env:
+            - name: WORDPRESS_HOME_URL
+              value: "https://evovelo.etsmtl.ca"
+            - name: WORDPRESS_SITE_URL
+              value: "https://evovelo.etsmtl.ca"
+          envFrom:
+            - secretRef:
+                name: veloom-secret
+          ports:
+            - name: http
+              containerPort: 80
+          startupProbe:
+            tcpSocket:
+              port: http
+            failureThreshold: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /wp-login.php
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: veloom-wordpress-persistent-storage
+              mountPath: /var/www/html
+            - name: php-config
+              mountPath: /usr/local/etc/php/conf.d/uploads.ini
+              subPath: uploads.ini
+          resources:
+            requests:
+              cpu: 4
+              memory: 1024Mi
+              ephemeral-storage: 256Mi
+            limits:
+              cpu: 6
+              memory: 2048Mi
+              ephemeral-storage: 1Gi
+      volumes:
+        - name: veloom-wordpress-persistent-storage
+          persistentVolumeClaim:
+            claimName: veloom-wp-pv-claim
+        - name: php-config
+          configMap:
+            defaultMode: 420
+            name: wp-php-config
+      securityContext:
+        fsGroup: 1000
+        runAsUser: 1000
+        runAsGroup: 1000
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: veloom-wp-pv-claim
+  namespace: veloom
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: cephfs
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: wp-php-config
+data:
+  uploads.ini: |-
+    file_uploads = On
+    upload_max_filesize = 256M
+    post_max_size = 256M
+    memory_limit = 256M
+    max_execution_time = 600
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: veloom-wordpress-pdb
+  namespace: veloom
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: veloom
+      tier: frontend

--- a/apps/clubs/veloom/wordpress/base/kustomization.yaml
+++ b/apps/clubs/veloom/wordpress/base/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml
+  - networkpolicy.yaml
+  - db/statefulset.yaml
+  - db/service.yaml
+
+namespace: veloom

--- a/apps/clubs/veloom/wordpress/base/networkpolicy.yaml
+++ b/apps/clubs/veloom/wordpress/base/networkpolicy.yaml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: veloom-wordpress-allow-all
+  namespace: veloom
+spec:
+  podSelector:
+    matchLabels:
+      app: veloom
+      tier: frontend
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: veloom-mysql-allow-all
+  namespace: veloom
+spec:
+  podSelector:
+    matchLabels:
+      app: mysql
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - {}
+  egress:
+    - {}

--- a/apps/clubs/veloom/wordpress/base/service.yaml
+++ b/apps/clubs/veloom/wordpress/base/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: veloom-svc
+spec:
+  selector:
+    app: veloom
+  ports:
+    - name: http
+      targetPort: 80
+      protocol: TCP
+      port: 80

--- a/apps/clubs/veloom/wordpress/prod/ingress.yaml
+++ b/apps/clubs/veloom/wordpress/prod/ingress.yaml
@@ -1,0 +1,40 @@
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: evovelo
+spec:
+  virtualhost:
+    fqdn: evovelo.etsmtl.ca
+    tls:
+      secretName: veloom-prod-tls
+    corsPolicy:
+      allowOrigin:
+        - "https://evovelo.etsmtl.ca"
+        - "https://evovelo.cedille.club"
+      allowMethods:
+        - "*"
+      allowHeaders:
+        - "*"
+  routes:
+    - conditions:
+        - prefix: /
+      services:
+        - name: veloom-svc
+          port: 80
+      requestHeadersPolicy:
+        set:
+          - name: X-Forwarded-Proto
+            value: https
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: veloom-prod-tls
+spec:
+  secretName: veloom-prod-tls
+  issuerRef:
+    name: letsencrypt-http
+    kind: ClusterIssuer
+  commonName: evovelo.etsmtl.ca
+  dnsNames:
+    - evovelo.etsmtl.ca

--- a/apps/clubs/veloom/wordpress/prod/kustomization.yaml
+++ b/apps/clubs/veloom/wordpress/prod/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../base
+  - ingress.yaml
+  - staging-ingress.yaml
+
+namespace: veloom

--- a/apps/clubs/veloom/wordpress/prod/staging-ingress.yaml
+++ b/apps/clubs/veloom/wordpress/prod/staging-ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: veloom-staging-ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+    ingress.kubernetes.io/force-ssl-redirect: "true"
+    kubernetes.io/tls-acme: "true"
+spec:
+  ingressClassName: contour
+  tls:
+    - hosts:
+        - evovelo.prodv2.cedille.club
+      secretName: veloom-staging-tls
+  rules:
+    - host: evovelo.prodv2.cedille.club
+      http:
+        paths:
+          - pathType: Prefix
+            path: /
+            backend:
+              service:
+                name: veloom-svc
+                port:
+                  number: 80

--- a/apps/clubs/veloom/wordpress/veloom-wordpress.argoapp.yaml
+++ b/apps/clubs/veloom/wordpress/veloom-wordpress.argoapp.yaml
@@ -1,0 +1,22 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: veloom-wordpress
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+spec:
+  project: k8s-shared
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: veloom
+  source:
+    repoURL: https://github.com/ClubCedille/k8s-shared
+    path: apps/clubs/veloom/wordpress/prod
+    targetRevision: HEAD
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+    automated:
+      selfHeal: true
+      prune: true

--- a/system/argocd/resources/argocd-projects.yaml
+++ b/system/argocd/resources/argocd-projects.yaml
@@ -87,11 +87,17 @@ spec:
   sourceRepos:
     - 'https://github.com/ClubCedille/k8s-cedille-production-v2'
     - 'https://github.com/ClubCedille/k8s-cedille-production-v2.git'
+    - 'https://github.com/ClubCedille/k8s-shared'
+    - 'https://github.com/ClubCedille/k8s-shared.git'
   destinations:
     - namespace: markets
       server: 'https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2'
     - namespace: markets-dev
       server: 'https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2'
+    - namespace: markets
+      server: 'https://kubernetes.default.svc'
+    - namespace: markets-dev
+      server: 'https://kubernetes.default.svc'
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'
@@ -128,6 +134,8 @@ spec:
       server: 'https://kubernetes.default.svc'
     - namespace: 'planifets*'
       server: 'https://cedille.kubernetes.omni.siderolabs.io?cluster=k8s-cedille-production-v2'
+    - namespace: 'planifets*'
+      server: 'https://kubernetes.default.svc'
   clusterResourceWhitelist:
     - group: '*'
       kind: '*'


### PR DESCRIPTION
## Migration of remaining stateful/team apps to k8s-shared

Single PR for the rest of the services targeted by the prodv2 → k8s-shared migration (meta-issue #230).

### Wordpress sites (ported verbatim from `apps/{club}/wordpress/`)
| App | Namespace | Hosts | Path |
|---|---|---|---|
| habitek-wordpress | habitek | habitek.ca (+ habitek.prodv2.cedille.club staging) | `apps/clubs/habitek/wordpress` |
| preci-wordpress | preci | preci.etsmtl.ca (HTTPProxy) | `apps/clubs/preci/wordpress` |
| veloom-wordpress | veloom | evovelo.etsmtl.ca (+ evovelo.prodv2.cedille.club staging) | `apps/clubs/veloom/wordpress` |

### Remaining apps
| App | Namespace | Project | Path |
|---|---|---|---|
| forom-shared | forom | k8s-shared | `apps/clubs/forom` |
| trema-shared | trema | k8s-shared | `apps/clubs/trema` |
| markets-shared / markets-dev-shared | markets / markets-dev | algoets | `apps/clubs/markets` |
| patchets-commande-shared | patchets | k8s-shared | `apps/clubs/patchets` |
| penpot-shared | penpot | k8s-shared | `apps/clubs/penpot` |
| planifets-shared [-staging -dev] | planifets* | applets | `apps/clubs/applets/planifets` |
| planifets-chatbot-shared [-staging -dev] | planifets* | applets | `apps/clubs/applets/planifets-chatbot` |
| data-acq-shared | data-acq | k8s-shared | `apps/clubs/comets/data_acq` |

### Included
- Manifests ported verbatim from prodv2 (kustomize + helmCharts), with:
  - patchets dropped un-referenced gitignored `secrets.yaml` and stale vendored `charts/` dir
  - planifets dropped gitignored `secret.org` and unwired `cnpg-secret.yaml`
  - wordpress apps: secrets are applied out-of-band (they travel with the velero namespace restore)
  - penpot: same as above for `penpot-secret`
- 16 new ArgoCD `Application` manifests (naming `{"club"}-{"app"}` / `-shared` to avoid collision with the old prodv2 argoapps still in the argocd namespace)
- `argocd-projects.yaml`: allow `algoets` and `applets` projects to source from `k8s-shared` and deploy to `https://kubernetes.default.svc`

### Not included (manual, like prior migrations, or noted)
- Velero namespace restores (habitek, veloom, preci, forom, trema, markets, markets-dev, patchets, penpot, planifets, planifets-staging, planifets-dev, data-acq) — run after merge, via the existing `migration` BSL. PVCs, DB secrets, wordpress uploads, `penpot-secret`, `cnpg-secret`, `markets-env-secret`, grafana/influx secrets all come from the restore.
- DNS repoint in Cloudflare to the shared cluster once cut over.
- `argocd/patchets-pull` image-updater pull secret doesn't exist on k8s-shared yet (dropped the annotation; add when creating the secret).
- `planifets` prod namespace already has a velero-restored workload on k8s-shared (labels `velero.io/restore-name: planifets-test-restore`); the new app will adopt it.
