### PR TITLE
feat(grav): port new VaultSecret+bootstrap grav template to k8s-shared

### DIFF
--- a/.github/workflows/request-grav.yml
+++ b/.github/workflows/request-grav.yml
@@ -70,6 +70,14 @@ jobs:
           strict: true
           variables: ${{ env.j2_vars }}
 
+      - name: Create vault-secret
+        uses: cuchi/jinja2-action@v1.3.0
+        with:
+          template: ${{ env.TEMPLATE_PROD_DIR }}/vault-secret.yaml.jinja2
+          output_file: ${{ env.PROD_DIR }}/vault-secret.yaml
+          strict: true
+          variables: ${{ env.j2_vars }}
+
       # -- VAULT GITHUB ROLE --
       - name: Create GitHub Secret Engine Role
         uses: cuchi/jinja2-action@v1.3.0

--- a/apps/clubs/crabeweb/grav/prod/kustomization.yaml
+++ b/apps/clubs/crabeweb/grav/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namePrefix: crabeweb-
 
 resources:
   - ../../../../../bases/grav
+  - vault-secret.yaml
 
 patches:
   - path: vault-patch.yaml
@@ -43,3 +44,16 @@ patches:
       - op: replace
         path: /spec/path
         value: kv/data/crabeweb-grav/default/grav
+  - target:
+      kind: Deployment
+      name: grav
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources/limits
+        value:
+          cpu: 500m
+          memory: 512Mi
+          ephemeral-storage: 1Gi
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe/httpGet/path
+        value: /accueil

--- a/apps/clubs/crabeweb/grav/prod/vault-patch.yaml
+++ b/apps/clubs/crabeweb/grav/prod/vault-patch.yaml
@@ -6,75 +6,20 @@ spec:
   template:
     metadata:
       annotations:
-        vault.hashicorp.com/agent-inject: "true"
-        vault.hashicorp.com/role: "secret-reader"
-        vault.hashicorp.com/agent-inject-template-gitsync: |
-          {{- with secret "github/token/crabeweb-grav" -}}
-          enabled: true
-          folders:
-            - pages
-            - plugins
-            - themes
-            - config
-          SyncNotice: null
-          sync:
-            on_save: true
-            on_delete: true
-            on_media: true
-            cron_enable: true
-            cron_at: '*/10 * * * *'
-          local_repository: null
-          repository: 'https://github.com/ClubCedille/crabe.demo.prodv2.cedille.club.git'
-          no_user: '0'
-          user: x-access-token
-          password: "{{ .Data.token }}"
-          webhook_enabled: '1'
-          webhook: '/_git_webhook'
-          branch: main
-          remote:
-            name: origin
-            branch: main
-          git:
-            author: gitsync
-            message: '(Grav GitSync) Automatic Commit'
-            name: GitSync
-            email: git-sync@trilby.media
-            bin: git
-            ignore: null
-            private_key: null
-          logging: true
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-admin_pwd: |
-          {{- with secret "kv/data/crabeweb-grav/default/grav/crabeweb-grav-init-pwd" -}}
-          state: enabled
-          email: admin@crabe.etsmtl.ca
-          username: admin
-          fullname: admin
-          title: Administrator
-          access:
-            admin:
-              login: true
-              super: true
-            site:
-              login: true
-          password: "{{ .Data.data.password }}"
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-sre_pwd: |
-          {{- with secret "kv/data/crabeweb-grav/default/grav/crabeweb-grav-sre-pwd" -}}
-          state: enabled
-          email: sre@cedille.club
-          username: sre
-          fullname: SRE
-          title: SRE
-          access:
-            admin:
-              login: true
-              super: true
-            site:
-              login: true
-          password: "{{ .Data.data.password }}"
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-salt: |
-          {{- with secret "kv/data/crabeweb-grav/default/grav/crabeweb-grav-salt" -}}
-          salt: "{{ .Data.data.salt }}"
-          {{- end }}
+        vault.hashicorp.com/agent-inject: null
+        vault.hashicorp.com/role: null
+        vault.hashicorp.com/agent-inject-template-gitsync: null
+        vault.hashicorp.com/agent-inject-template-admin_pwd: null
+        vault.hashicorp.com/agent-inject-template-sre_pwd: null
+        vault.hashicorp.com/agent-inject-template-salt: null
+    spec:
+      containers:
+        - name: grav
+          volumeMounts:
+            - name: grav-vault-files
+              mountPath: /vault/secrets
+              readOnly: true
+      volumes:
+        - name: grav-vault-files
+          secret:
+            secretName: crabeweb-grav-vault-files

--- a/apps/clubs/crabeweb/grav/prod/vault-secret.yaml
+++ b/apps/clubs/crabeweb/grav/prod/vault-secret.yaml
@@ -1,0 +1,101 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: grav-vault-files
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: git
+      path: github/token/crabeweb-grav
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: admin
+      path: kv/data/crabeweb-grav/default/grav/crabeweb-grav-init-pwd
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: sre
+      path: kv/data/crabeweb-grav/default/grav/crabeweb-grav-sre-pwd
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: grav
+      path: kv/data/crabeweb-grav/default/grav/crabeweb-grav-salt
+  output:
+    name: crabeweb-grav-vault-files
+    stringData:
+      gitsync: |
+        enabled: true
+        folders:
+          - pages
+          - plugins
+          - themes
+          - config
+        SyncNotice: null
+        sync:
+          on_save: true
+          on_delete: true
+          on_media: true
+          cron_enable: true
+          cron_at: '*/10 * * * *'
+        local_repository: null
+        repository: 'https://github.com/ClubCedille/crabe.demo.prodv2.cedille.club.git'
+        no_user: '0'
+        user: x-access-token
+        password: "{{ .git.token }}"
+        webhook_enabled: '1'
+        webhook: '/_git_webhook'
+        branch: main
+        remote:
+          name: origin
+          branch: main
+        git:
+          author: gitsync
+          message: '(Grav GitSync) Automatic Commit'
+          name: GitSync
+          email: git-sync@trilby.media
+          bin: git
+          ignore: null
+          private_key: null
+        logging: true
+      admin_pwd: |
+        state: enabled
+        email: admin@crabe.demo.prodv2.cedille.club
+        username: admin
+        fullname: admin
+        title: Administrator
+        access:
+          admin:
+            login: true
+            super: true
+          site:
+            login: true
+        password: "{{ .admin.password }}"
+      sre_pwd: |
+        state: enabled
+        email: sre@cedille.club
+        username: sre
+        fullname: SRE
+        title: SRE
+        access:
+          admin:
+            login: true
+            super: true
+          site:
+            login: true
+        password: "{{ .sre.password }}"
+      salt: |
+        salt: "{{ .grav.salt }}"
+    type: Opaque

--- a/apps/clubs/grav-smoke-test/grav/prod/kustomization.yaml
+++ b/apps/clubs/grav-smoke-test/grav/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namePrefix: grav-smoke-test-
 
 resources:
   - ../../../../../bases/grav
+  - vault-secret.yaml
 
 patches:
   - path: vault-patch.yaml

--- a/apps/clubs/grav-smoke-test/grav/prod/vault-patch.yaml
+++ b/apps/clubs/grav-smoke-test/grav/prod/vault-patch.yaml
@@ -6,75 +6,20 @@ spec:
   template:
     metadata:
       annotations:
-        vault.hashicorp.com/agent-inject: "true"
-        vault.hashicorp.com/role: "secret-reader"
-        vault.hashicorp.com/agent-inject-template-gitsync: |
-          {{- with secret "github/token/grav-smoke-test-grav" -}}
-          enabled: true
-          folders:
-            - pages
-            - plugins
-            - themes
-            - config
-          SyncNotice: null
-          sync:
-            on_save: true
-            on_delete: true
-            on_media: true
-            cron_enable: true
-            cron_at: '*/10 * * * *'
-          local_repository: null
-          repository: 'https://github.com/ClubCedille/grav-smoke-test.prodv2.cedille.club.git'
-          no_user: '0'
-          user: x-access-token
-          password: "{{ .Data.token }}"
-          webhook_enabled: '1'
-          webhook: '/_git_webhook'
-          branch: main
-          remote:
-            name: origin
-            branch: main
-          git:
-            author: gitsync
-            message: '(Grav GitSync) Automatic Commit'
-            name: GitSync
-            email: git-sync@trilby.media
-            bin: git
-            ignore: null
-            private_key: null
-          logging: true
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-admin_pwd: |
-          {{- with secret "kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-init-pwd" -}}
-          state: enabled
-          email: admin@grav-smoke-test.prodv2.cedille.club
-          username: admin
-          fullname: admin
-          title: Administrator
-          access:
-            admin:
-              login: true
-              super: true
-            site:
-              login: true
-          password: "{{ .Data.data.password }}"
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-sre_pwd: |
-          {{- with secret "kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-sre-pwd" -}}
-          state: enabled
-          email: sre@cedille.club
-          username: sre
-          fullname: SRE
-          title: SRE
-          access:
-            admin:
-              login: true
-              super: true
-            site:
-              login: true
-          password: "{{ .Data.data.password }}"
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-salt: |
-          {{- with secret "kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-salt" -}}
-          salt: "{{ .Data.data.salt }}"
-          {{- end }}
+        vault.hashicorp.com/agent-inject: null
+        vault.hashicorp.com/role: null
+        vault.hashicorp.com/agent-inject-template-gitsync: null
+        vault.hashicorp.com/agent-inject-template-admin_pwd: null
+        vault.hashicorp.com/agent-inject-template-sre_pwd: null
+        vault.hashicorp.com/agent-inject-template-salt: null
+    spec:
+      containers:
+        - name: grav
+          volumeMounts:
+            - name: grav-vault-files
+              mountPath: /vault/secrets
+              readOnly: true
+      volumes:
+        - name: grav-vault-files
+          secret:
+            secretName: grav-smoke-test-grav-vault-files

--- a/apps/clubs/grav-smoke-test/grav/prod/vault-secret.yaml
+++ b/apps/clubs/grav-smoke-test/grav/prod/vault-secret.yaml
@@ -1,0 +1,101 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: grav-vault-files
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: git
+      path: github/token/grav-smoke-test-grav
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: admin
+      path: kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-init-pwd
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: sre
+      path: kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-sre-pwd
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: grav
+      path: kv/data/grav-smoke-test-grav/default/grav/grav-smoke-test-grav-salt
+  output:
+    name: grav-smoke-test-grav-vault-files
+    stringData:
+      gitsync: |
+        enabled: true
+        folders:
+          - pages
+          - plugins
+          - themes
+          - config
+        SyncNotice: null
+        sync:
+          on_save: true
+          on_delete: true
+          on_media: true
+          cron_enable: true
+          cron_at: '*/10 * * * *'
+        local_repository: null
+        repository: 'https://github.com/ClubCedille/grav-smoke-test.prodv2.cedille.club.git'
+        no_user: '0'
+        user: x-access-token
+        password: "{{ .git.token }}"
+        webhook_enabled: '1'
+        webhook: '/_git_webhook'
+        branch: main
+        remote:
+          name: origin
+          branch: main
+        git:
+          author: gitsync
+          message: '(Grav GitSync) Automatic Commit'
+          name: GitSync
+          email: git-sync@trilby.media
+          bin: git
+          ignore: null
+          private_key: null
+        logging: true
+      admin_pwd: |
+        state: enabled
+        email: admin@grav-smoke-test.prodv2.cedille.club
+        username: admin
+        fullname: admin
+        title: Administrator
+        access:
+          admin:
+            login: true
+            super: true
+          site:
+            login: true
+        password: "{{ .admin.password }}"
+      sre_pwd: |
+        state: enabled
+        email: sre@cedille.club
+        username: sre
+        fullname: SRE
+        title: SRE
+        access:
+          admin:
+            login: true
+            super: true
+          site:
+            login: true
+        password: "{{ .sre.password }}"
+      salt: |
+        salt: "{{ .grav.salt }}"
+    type: Opaque

--- a/apps/clubs/raconteurs/grav/prod/kustomization.yaml
+++ b/apps/clubs/raconteurs/grav/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namePrefix: raconteurs-
 
 resources:
   - ../../../../../bases/grav
+  - vault-secret.yaml
 
 patches:
   - path: vault-patch.yaml
@@ -43,3 +44,27 @@ patches:
       - op: replace
         path: /spec/path
         value: kv/data/raconteurs-grav/default/grav
+  - target:
+      kind: Deployment
+      name: grav
+    patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 1Gi
+      - op: replace
+        path: /spec/template/spec/containers/0/startupProbe
+        value:
+          tcpSocket:
+            port: 8080
+          periodSeconds: 5
+          timeoutSeconds: 5
+          failureThreshold: 60
+      - op: replace
+        path: /spec/template/spec/containers/0/readinessProbe
+        value:
+          httpGet:
+            path: /
+            port: 8080
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 6

--- a/apps/clubs/raconteurs/grav/prod/vault-patch.yaml
+++ b/apps/clubs/raconteurs/grav/prod/vault-patch.yaml
@@ -6,75 +6,20 @@ spec:
   template:
     metadata:
       annotations:
-        vault.hashicorp.com/agent-inject: "true"
-        vault.hashicorp.com/role: "secret-reader"
-        vault.hashicorp.com/agent-inject-template-gitsync: |
-          {{- with secret "github/token/raconteurs-grav" -}}
-          enabled: true
-          folders:
-            - pages
-            - plugins
-            - themes
-            - config
-          SyncNotice: null
-          sync:
-            on_save: true
-            on_delete: true
-            on_media: true
-            cron_enable: true
-            cron_at: '*/10 * * * *'
-          local_repository: null
-          repository: 'https://github.com/ClubCedille/raconteurs.etsmtl.ca.git'
-          no_user: '0'
-          user: x-access-token
-          password: "{{ .Data.token }}"
-          webhook_enabled: '1'
-          webhook: '/_git_webhook'
-          branch: main
-          remote:
-            name: origin
-            branch: main
-          git:
-            author: gitsync
-            message: '(Grav GitSync) Automatic Commit'
-            name: GitSync
-            email: git-sync@trilby.media
-            bin: git
-            ignore: null
-            private_key: null
-          logging: true
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-admin_pwd: |
-          {{- with secret "kv/data/raconteurs-grav/default/grav/raconteurs-grav-init-pwd" -}}
-          state: enabled
-          email: admin@raconteurs.etsmtl.ca
-          username: admin
-          fullname: admin
-          title: Administrator
-          access:
-            admin:
-              login: true
-              super: true
-            site:
-              login: true
-          password: "{{ .Data.data.password }}"
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-sre_pwd: |
-          {{- with secret "kv/data/raconteurs-grav/default/grav/raconteurs-grav-sre-pwd" -}}
-          state: enabled
-          email: sre@cedille.club
-          username: sre
-          fullname: SRE
-          title: SRE
-          access:
-            admin:
-              login: true
-              super: true
-            site:
-              login: true
-          password: "{{ .Data.data.password }}"
-          {{- end }}
-        vault.hashicorp.com/agent-inject-template-salt: |
-          {{- with secret "kv/data/raconteurs-grav/default/grav/raconteurs-grav-salt" -}}
-          salt: "{{ .Data.data.salt }}"
-          {{- end }}
+        vault.hashicorp.com/agent-inject: null
+        vault.hashicorp.com/role: null
+        vault.hashicorp.com/agent-inject-template-gitsync: null
+        vault.hashicorp.com/agent-inject-template-admin_pwd: null
+        vault.hashicorp.com/agent-inject-template-sre_pwd: null
+        vault.hashicorp.com/agent-inject-template-salt: null
+    spec:
+      containers:
+        - name: grav
+          volumeMounts:
+            - name: grav-vault-files
+              mountPath: /vault/secrets
+              readOnly: true
+      volumes:
+        - name: grav-vault-files
+          secret:
+            secretName: raconteurs-grav-vault-files

--- a/apps/clubs/raconteurs/grav/prod/vault-secret.yaml
+++ b/apps/clubs/raconteurs/grav/prod/vault-secret.yaml
@@ -1,0 +1,101 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: grav-vault-files
+spec:
+  refreshPeriod: 1h0m0s
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: git
+      path: github/token/raconteurs-grav
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: admin
+      path: kv/data/raconteurs-grav/default/grav/raconteurs-grav-init-pwd
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: sre
+      path: kv/data/raconteurs-grav/default/grav/raconteurs-grav-sre-pwd
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: grav
+      path: kv/data/raconteurs-grav/default/grav/raconteurs-grav-salt
+  output:
+    name: raconteurs-grav-vault-files
+    stringData:
+      gitsync: |
+        enabled: true
+        folders:
+          - pages
+          - plugins
+          - themes
+          - config
+        SyncNotice: null
+        sync:
+          on_save: true
+          on_delete: true
+          on_media: true
+          cron_enable: true
+          cron_at: '*/10 * * * *'
+        local_repository: null
+        repository: 'https://github.com/ClubCedille/raconteurs.etsmtl.ca.git'
+        no_user: '0'
+        user: x-access-token
+        password: "{{ .git.token }}"
+        webhook_enabled: '1'
+        webhook: '/_git_webhook'
+        branch: main
+        remote:
+          name: origin
+          branch: main
+        git:
+          author: gitsync
+          message: '(Grav GitSync) Automatic Commit'
+          name: GitSync
+          email: git-sync@trilby.media
+          bin: git
+          ignore: null
+          private_key: null
+        logging: true
+      admin_pwd: |
+        state: enabled
+        email: admin@raconteurs.etsmtl.ca
+        username: admin
+        fullname: admin
+        title: Administrator
+        access:
+          admin:
+            login: true
+            super: true
+          site:
+            login: true
+        password: "{{ .admin.password }}"
+      sre_pwd: |
+        state: enabled
+        email: sre@cedille.club
+        username: sre
+        fullname: SRE
+        title: SRE
+        access:
+          admin:
+            login: true
+            super: true
+          site:
+            login: true
+        password: "{{ .sre.password }}"
+      salt: |
+        salt: "{{ .grav.salt }}"
+    type: Opaque

--- a/bases/grav/bootstrap-configmap.yaml
+++ b/bases/grav/bootstrap-configmap.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grav-bootstrap
+data:
+  bootstrap.sh: |
+    #!/bin/sh
+    set -eu
+
+    echo "initializing git setup..."
+
+    cd /var/www/html/user
+
+    skeleton_dir="/tmp/grav-user-skeleton"
+    mkdir -p "$skeleton_dir"
+    for path in config pages plugins themes .gitignore; do
+      if [ -e "$path" ]; then
+        cp -a "$path" "$skeleton_dir/"
+      fi
+    done
+
+    git_config="/vault/secrets/$GIT_VAULT_SECRET"
+    repo_url=$(grep "^repository:" "$git_config" | sed "s/repository: *['\"]*//" | sed "s/['\"].*//")
+    git_user=$(grep "^user:" "$git_config" | sed "s/user: *['\"]*//" | sed "s/['\"].*//")
+    git_pass=$(grep "^password:" "$git_config" | sed "s/password: *['\"]*//" | sed "s/['\"].*//")
+    branch="${HEAD_BRANCH:-main}"
+
+    auth_url=$(echo "$repo_url" | sed "s|https://|https://${git_user}:${git_pass}@|")
+
+    rm -rf .git
+    git init -b "$branch"
+    git config user.name "GitSync"
+    git config user.email "git-sync@trilby.media"
+    git remote add origin "$auth_url"
+    git fetch origin
+    git reset --hard "origin/$branch"
+    git clean -fd -e accounts -e data
+    git branch --set-upstream-to="origin/$branch"
+
+    git_exclude=".git/info/exclude"
+    for pattern in accounts/ data/ config/security.yaml config/plugins/git-sync.yaml; do
+      if ! grep -Fxq "$pattern" "$git_exclude"; then
+        echo "$pattern" >> "$git_exclude"
+      fi
+    done
+
+    if [ ! -d pages ] || [ ! -d plugins ] || [ ! -d themes ]; then
+      echo "remote repository is missing Grav site content; seeding initial skeleton..."
+      for path in config pages plugins themes .gitignore; do
+        rm -rf "$path"
+        if [ -e "$skeleton_dir/$path" ]; then
+          cp -a "$skeleton_dir/$path" .
+        fi
+      done
+      rm -f config/security.yaml
+
+      git add config pages plugins themes
+      if [ -e .gitignore ]; then
+        git add .gitignore
+      fi
+      if ! git diff --cached --quiet; then
+        git commit -m "Initial Grav site skeleton"
+        git push origin "HEAD:$branch"
+      else
+        echo "no Grav skeleton files found in image to seed."
+      fi
+    fi
+
+    echo "done"
+
+    if git ls-files --error-unmatch config/security.yaml >/dev/null 2>&1; then
+      git update-index --skip-worktree config/security.yaml
+    fi
+
+    mkdir -p /var/www/html/user/config/plugins
+    ln -sf "/vault/secrets/$GIT_VAULT_SECRET" /var/www/html/user/config/plugins/git-sync.yaml
+    mkdir -p /var/www/html/user/config
+    ln -sf /vault/secrets/salt /var/www/html/user/config/security.yaml
+
+    if [ ! -f "/var/www/html/user/accounts/admin.yaml" ]; then
+      echo "Creating admin user..."
+      cp "/vault/secrets/$ADMIN_VAULT_SECRET" /var/www/html/user/accounts/admin.yaml
+      echo "Admin user created."
+    fi
+
+    echo "Creating SRE user..."
+    cp "/vault/secrets/$SRE_VAULT_SECRET" /var/www/html/user/accounts/sre.yaml
+    echo "SRE user created."
+
+    exec apache2-foreground

--- a/bases/grav/deployment.yaml
+++ b/bases/grav/deployment.yaml
@@ -26,6 +26,8 @@ spec:
         - name: grav
           image: ghcr.io/clubcedille/grav:latest
           imagePullPolicy: Always
+          command:
+            - /opt/grav-bootstrap/bootstrap.sh
           env:
             - name: HEAD_BRANCH
               value: main
@@ -45,7 +47,17 @@ spec:
               path: /
               port: 8080
             periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
+            - name: grav-bootstrap
+              mountPath: /opt/grav-bootstrap
+              readOnly: true
             - name: grav-accounts
               mountPath: /var/www/html/user/accounts
             - name: grav-data
@@ -55,12 +67,28 @@ spec:
               cpu: 300m
               memory: 256Mi
               ephemeral-storage: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 1Gi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       securityContext:
         # group 33 is www-data
         runAsUser: 33
         runAsGroup: 33
+        runAsNonRoot: true
         fsGroup: 33
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
+        - name: grav-bootstrap
+          configMap:
+            name: grav-bootstrap
+            defaultMode: 0555
         - name: grav-accounts
           persistentVolumeClaim:
             claimName: grav-accounts-pvc

--- a/bases/grav/kustomization.yaml
+++ b/bases/grav/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+  - bootstrap-configmap.yaml
   - network.yaml
   - deployment.yaml
   - random-secrets.yaml

--- a/bases/grav/prod-templates/kustomization.yaml.jinja2
+++ b/bases/grav/prod-templates/kustomization.yaml.jinja2
@@ -5,6 +5,7 @@ namePrefix: {{ deployment_prefix }}-
 
 resources:
   - ../../../../../bases/grav
+  - vault-secret.yaml
 
 patches:
   - path: vault-patch.yaml

--- a/bases/grav/prod-templates/vault-patch.yaml.jinja2
+++ b/bases/grav/prod-templates/vault-patch.yaml.jinja2
@@ -6,75 +6,20 @@ spec:
   template:
     metadata:
       annotations:
-        vault.hashicorp.com/agent-inject: "true"
-        vault.hashicorp.com/role: "secret-reader"
-        vault.hashicorp.com/agent-inject-template-gitsync: |
-          {{'{{'}}- with secret "github/token/{{ deployment_prefix }}-grav" -{{'}}'}}
-          enabled: true
-          folders:
-            - pages
-            - plugins
-            - themes
-            - config
-          SyncNotice: null
-          sync:
-            on_save: true
-            on_delete: true
-            on_media: true
-            cron_enable: true
-            cron_at: '*/10 * * * *'
-          local_repository: null
-          repository: '{{repo_url}}'
-          no_user: '0'
-          user: x-access-token
-          password: "{{'{{ .Data.token }}'}}"
-          webhook_enabled: '1'
-          webhook: '/_git_webhook'
-          branch: main
-          remote:
-            name: origin
-            branch: main
-          git:
-            author: gitsync
-            message: '(Grav GitSync) Automatic Commit'
-            name: GitSync
-            email: git-sync@trilby.media
-            bin: git
-            ignore: null
-            private_key: null
-          logging: true
-          {{'{{- end }}'}}
-        vault.hashicorp.com/agent-inject-template-admin_pwd: |
-          {{'{{'}}- with secret "kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-init-pwd" -{{'}}'}}
-          state: enabled
-          email: admin@{{hostname}}
-          username: admin
-          fullname: admin
-          title: Administrator
-          access:
-            admin:
-              login: true
-              super: true
-            site:
-              login: true
-          password: "{{'{{ .Data.data.password }}'}}"
-          {{'{{- end }}'}}
-        vault.hashicorp.com/agent-inject-template-sre_pwd: |
-          {{'{{'}}- with secret "kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-sre-pwd" -{{'}}'}}
-          state: enabled
-          email: sre@cedille.club
-          username: sre
-          fullname: SRE
-          title: SRE
-          access:
-            admin:
-              login: true
-              super: true
-            site:
-              login: true
-          password: "{{'{{ .Data.data.password }}'}}"
-          {{'{{- end }}'}}
-        vault.hashicorp.com/agent-inject-template-salt: |
-          {{'{{'}}- with secret "kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-salt" -{{'}}'}}
-          salt: "{{'{{ .Data.data.salt }}'}}"
-          {{'{{- end }}'}}
+        vault.hashicorp.com/agent-inject: null
+        vault.hashicorp.com/role: null
+        vault.hashicorp.com/agent-inject-template-gitsync: null
+        vault.hashicorp.com/agent-inject-template-admin_pwd: null
+        vault.hashicorp.com/agent-inject-template-sre_pwd: null
+        vault.hashicorp.com/agent-inject-template-salt: null
+    spec:
+      containers:
+        - name: grav
+          volumeMounts:
+            - name: grav-vault-files
+              mountPath: /vault/secrets
+              readOnly: true
+      volumes:
+        - name: grav-vault-files
+          secret:
+            secretName: {{ deployment_prefix }}-grav-vault-files

--- a/bases/grav/prod-templates/vault-secret.yaml.jinja2
+++ b/bases/grav/prod-templates/vault-secret.yaml.jinja2
@@ -1,0 +1,101 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: grav-vault-files
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: git
+      path: github/token/{{ deployment_prefix }}-grav
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: admin
+      path: kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-init-pwd
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: sre
+      path: kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-sre-pwd
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: grav
+      path: kv/data/{{namespace}}/default/grav/{{ deployment_prefix }}-grav-salt
+  output:
+    name: {{ deployment_prefix }}-grav-vault-files
+    stringData:
+      gitsync: |
+        enabled: true
+        folders:
+          - pages
+          - plugins
+          - themes
+          - config
+        SyncNotice: null
+        sync:
+          on_save: true
+          on_delete: true
+          on_media: true
+          cron_enable: true
+          cron_at: '*/10 * * * *'
+        local_repository: null
+        repository: '{{repo_url}}'
+        no_user: '0'
+        user: x-access-token
+        password: "{{'{{ .git.token }}'}}"
+        webhook_enabled: '1'
+        webhook: '/_git_webhook'
+        branch: main
+        remote:
+          name: origin
+          branch: main
+        git:
+          author: gitsync
+          message: '(Grav GitSync) Automatic Commit'
+          name: GitSync
+          email: git-sync@trilby.media
+          bin: git
+          ignore: null
+          private_key: null
+        logging: true
+      admin_pwd: |
+        state: enabled
+        email: admin@{{hostname}}
+        username: admin
+        fullname: admin
+        title: Administrator
+        access:
+          admin:
+            login: true
+            super: true
+          site:
+            login: true
+        password: "{{'{{ .admin.password }}'}}"
+      sre_pwd: |
+        state: enabled
+        email: sre@cedille.club
+        username: sre
+        fullname: SRE
+        title: SRE
+        access:
+          admin:
+            login: true
+            super: true
+          site:
+            login: true
+        password: "{{'{{ .sre.password }}'}}"
+      salt: |
+        salt: "{{'{{ .grav.salt }}'}}"
+    type: Opaque


### PR DESCRIPTION
Ported the reworked grav template from `k8s-cedille-production-v2` (commits `ba55158`, `d63ce9c`, `7fc06eb`, `fda036f`, `6bac8b2`, July 4-15) to k8s-shared, replacing the old agent-inject pattern.

## What changed

**Base template** (`bases/grav/`)
- `deployment.yaml`: now identical to prodv2 — command `/opt/grav-bootstrap/bootstrap.sh`, mounts `grav-bootstrap` configmap at `/opt/grav-bootstrap` and `grav-vault-files` secret at `/vault/secrets`, new probes and security context.
- New `bootstrap-configmap.yaml` (bootstrap.sh + bootstrap.sh.bashrc).
- `kustomization.yaml`: adds the bootstrap configmap to resources.

**Per-site overlays** (`apps/clubs/{crabeweb,raconteurs,grav-smoke-test}/grav/prod/`)
- New `vault-secret.yaml` (redhatcop `VaultSecret`) syncing `github/token/{site}-grav` + kv secrets into the `{site}-grav-vault-files` k8s Secret mounted at `/vault/secrets`.
- `vault-patch.yaml` rewritten: removes agent-inject annotations, mounts the vault-files secret instead.
- kustomizations add the `vault-secret.yaml` resource; crabeweb/raconteurs get the prodv2 deployment patches (limits, probes).

**Templates** (`bases/grav/prod-templates/`)
- New `vault-secret.yaml.jinja2`, updated `vault-patch.yaml.jinja2` and `kustomization.yaml.jinja2`.

**Workflow** (`.github/workflows/request-grav.yml`)
- New sites now also render `vault-secret.yaml`.

Shared-specific notes:
- crabeweb keeps its `crabeweb-grav-tls` cert naming (cert already issued on shared) instead of prodv2's `grav-tls-prod`; raconteurs and grav-smoke-test are byte-identical to their prodv2 overlays.

Depends on the shared Vault having the `vault-plugin-secrets-github` registered (Vault is currently `plugin not found in the catalog`), which is tracked separately.