### PR TITLE
fix(crabe): add VaultSecrets for webapp-crabe secrets and ghcr pull

### DIFF
--- a/apps/clubs/crabe/web/prod/kustomization.yaml
+++ b/apps/clubs/crabe/web/prod/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ../base/
   - ingress.yaml
+  - vault-secret.yaml

--- a/apps/clubs/crabe/web/prod/vault-secret.yaml
+++ b/apps/clubs/crabe/web/prod/vault-secret.yaml
@@ -1,0 +1,51 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: ghcr-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: docker
+      path: kv-system/default_passwords/docker-crabe
+  output:
+    name: ghcr-secret
+    stringData:
+      .dockerconfigjson: '{{ b64dec .docker.config }}'
+    type: kubernetes.io/dockerconfigjson
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: webapp-crabe-config
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: crabe
+      path: kv/data/webapp-crabe/default/config
+  output:
+    name: webapp-crabe-secrets
+    stringData:
+      DB_DRIVER: '{{ .crabe.DB_DRIVER }}'
+      DB_HOST: '{{ .crabe.DB_HOST }}'
+      DB_NAME: '{{ .crabe.DB_NAME }}'
+      DB_PASSWORD: '{{ .crabe.DB_PASSWORD }}'
+      DB_ROOT_PASSWORD: '{{ .crabe.DB_ROOT_PASSWORD }}'
+      DB_USER: '{{ .crabe.DB_USER }}'
+      ITEMS_INVENTORY_PAGE: '{{ .crabe.ITEMS_INVENTORY_PAGE }}'
+      ITEMS_PER_PAGE_CONSOLE: '{{ .crabe.ITEMS_PER_PAGE_CONSOLE }}'
+      MYSQL_DATABASE: '{{ .crabe.MYSQL_DATABASE }}'
+      MYSQL_PASSWORD: '{{ .crabe.MYSQL_PASSWORD }}'
+      MYSQL_ROOT_PASSWORD: '{{ .crabe.MYSQL_ROOT_PASSWORD }}'
+      MYSQL_USER: '{{ .crabe.MYSQL_USER }}'
+      SITE_NAME: '{{ .crabe.SITE_NAME }}'
+    type: opaque


### PR DESCRIPTION
Fixes the crabe web app on shared which was failing (ImagePullBackOff + missing DB creds) after the earlier manifest-only migration.

- Adds `ghcr-secret` VaultSecret (dockerconfigjson for ghcr.io/crabe-etsmtl) from `kv-system/default_passwords/docker-crabe`
- Adds `webapp-crabe-config` VaultSecret → `webapp-crabe-secrets` (13 DB keys) from `kv/data/webapp-crabe/default/config`
- Wired into prod/kustomization.yaml

Live data imported separately (mysqldump of old cluster 'crabe' DB → 16 tables, 80-row inventaire). App Healthy, serving.