### PR TITLE
fix(crabe): use letsencrypt-http for crPBE TLS cert

### DIFF
--- a/apps/clubs/crabe/web/prod/ingress.yaml
+++ b/apps/clubs/crabe/web/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: crabe-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:


### PR DESCRIPTION
The crabe ingress used `letsencrypt-prod` (Cloudflare DNS-01), but the shared cluster's `cloudflare-token` only manages `etsmtl.club`/`lanets.ca` — not the `cedille.club` zone `atelier.crabe.cedille.club` lives under, so the challenge fails (`Found no Zones for domain _acme-challenge.atelier.crabe.cedille.club`).

Switch to `letsencrypt-http` (HTTP-01 via Contour) — same as the working `cedille.etsmtl.ca` cert — which needs no Cloudflare zone access since the hostname CNAMEs to the shared contour LB.