### PR TITLE
fix(certs): switch cedille.club ingresses to letsencrypt-http (HTTP-01)

### DIFF
--- a/apps/clubs/applets/planifets/dev/ingress.yaml
+++ b/apps/clubs/applets/planifets/dev/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: planifets-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/applets/planifets/prod/ingress.yaml
+++ b/apps/clubs/applets/planifets/prod/ingress.yaml
@@ -36,7 +36,7 @@ kind: Ingress
 metadata:
   name: planifets-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/applets/planifets/staging/ingress.yaml
+++ b/apps/clubs/applets/planifets/staging/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: planifets-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/calidum-rotae/prod/ingress.yaml
+++ b/apps/clubs/calidum-rotae/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: calidum-rotae-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
     gatus.cedille/protocol: "tcp"

--- a/apps/clubs/cedille/website/prod/ingress.yaml
+++ b/apps/clubs/cedille/website/prod/ingress.yaml
@@ -29,7 +29,7 @@ kind: Ingress
 metadata:
   name: cedille-prod
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/cedille/wiki-cedille/prod/ingress.yaml
+++ b/apps/clubs/cedille/wiki-cedille/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: wiki-cedille-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:
@@ -29,7 +29,7 @@ kind: Ingress
 metadata:
   name: wiki-cedille-ingress-stg
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/comets/data_acq/resources/grafana-ingress.yaml
+++ b/apps/clubs/comets/data_acq/resources/grafana-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: grafana-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/comets/data_acq/resources/influxdb2-ingress.yaml
+++ b/apps/clubs/comets/data_acq/resources/influxdb2-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: influxdb2-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/comets/website/prod/ingress.yaml
+++ b/apps/clubs/comets/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: comets-web-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/esports/website/prod/ingress.yaml
+++ b/apps/clubs/esports/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: esports
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/etshub/website/prod/ingress.yaml
+++ b/apps/clubs/etshub/website/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: etshub
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/forom/prod/ingress.yaml
+++ b/apps/clubs/forom/prod/ingress.yaml
@@ -30,7 +30,7 @@ kind: Ingress
 metadata:
   name: forom-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/habitek/wordpress/prod/staging-ingress.yaml
+++ b/apps/clubs/habitek/wordpress/prod/staging-ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: habitek-staging-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/markets/dev/ingress.yaml
+++ b/apps/clubs/markets/dev/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: markets-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/markets/prod/ingress.yaml
+++ b/apps/clubs/markets/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: markets-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 spec:

--- a/apps/clubs/trema/prod/ingress.yaml
+++ b/apps/clubs/trema/prod/ingress.yaml
@@ -3,7 +3,7 @@ kind: Ingress
 metadata:
   name: trema-ingress
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-http
     ingress.kubernetes.io/force-ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
     gatus.cedille/protocol: "tcp"


### PR DESCRIPTION
The shared cluster's Cloudflare `cloudflare-token` only manages `etsmtl.club` and `lanets.ca` — not the `cedille.club` zone family. All `letencrypt-prod` (DNS-01) certs for `*{`.`prodv2,` `.`dev,` `.`staging}`.cedille.club fail with `Found no Zones for domain _acme-challenge...`.

Affected apps with no working HTTPS right now:
- esports, etshub, markets-dev, planifets-dev, planifets-staging, wiki-cedille (both wiki.cedille.club + wiki.prodv2.cedille.club), calidum-rotae, cedille-prod, comets
- forom + planifets-prod have Velero-restored certs expiring Oct 30 / Sep 9 respectively — switched to renew before expiry instead of failing

All hostnames CNAME to the shared contour LB (142.137.247.75), so HTTP-01 via `letsencrypt-http` works (same fix as crabe PR #378, and identical to the working `cedille.etsmtl.ca` cert). No `cedille.club` host remains on `letsencrypt-prod`.