### PR TITLE
fix(ingenieuses): provision ghcr pull secret via VaultSecret

### DIFF
--- a/apps/clubs/ingenieuses/website/prod/kustomization.yaml
+++ b/apps/clubs/ingenieuses/website/prod/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ../base/
   - ingress.yaml
+  - vault-secret.yaml

--- a/apps/clubs/ingenieuses/website/prod/vault-secret.yaml
+++ b/apps/clubs/ingenieuses/website/prod/vault-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: ghcr-ingenieuses-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: docker
+      path: kv-system/default_passwords/docker-ingenieuses
+  output:
+    name: ghcr-ingenieuses-secret
+    stringData:
+      .dockerconfigjson: '{{ b64dec .docker.config }}'
+    type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Provisions the missing `ghcr-ingenieuses-secret` dockerconfigjson secret in the `ingenieuses` namespace so the deployment can pull `ghcr.io/les-ingenieuses-de-l-ets/web-ingenieuses` (currently ImagePullBackOff / 401 Unauthorized).

- New VaultSecret following the crabe/esports/etshub pattern (output dockerconfigjson, `{{ b64dec .docker.config }}` from `kv-system/default_passwords/docker-ingenieuses`).
- Vault entry written from the prodv2 secret (PAT user `liltl`, org `les-ingenieuses-de-l-ets`).
- Added to prod kustomization.