### PR TITLE
fix(markets): provision ghcr pull secret in dev namespace

### DIFF
--- a/apps/clubs/markets/dev/kustomization.yaml
+++ b/apps/clubs/markets/dev/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../base
   - ingress.yaml
   - configMap.yaml
+  - vault-secret.yaml
 
 patchesStrategicMerge:
   - patch-backend-image.yaml

--- a/apps/clubs/markets/dev/vault-secret.yaml
+++ b/apps/clubs/markets/dev/vault-secret.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: ghcr-markets-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: docker
+      path: kv-system/default_passwords/docker-markets
+  output:
+    name: ghcr-markets-secret
+    stringData:
+      .dockerconfigjson: '{{ b64dec .docker.config }}'
+    type: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
Fixes ImagePullBackOff in `markets-dev`: deployments reference `ghcr-markets-secret` but it only existed in the `markets` (prod) and `argocd` namespaces.

- New VaultSecret `ghcr-markets-secret` in `apps/clubs/markets/dev/` (output dockerconfigjson, `{{ b64dec .docker.config }}` from `kv-system/default_passwords/docker-markets`).
- Vault entry written from the prod secret creds (PAT user `oli3161`, org `algoets`).
- Added to dev kustomization.

Prod intentionally untouched: its `ghcr-markets-secret` is a working Velero-restored secret; adding a same-named VaultSecret there would ReconcileFailed (`secret not owned by VaultSecret`) unless the restored secret is removed first.