### PR TITLE
fix(markets): provision markets-env-secret in dev namespace

### DIFF
--- a/apps/clubs/markets/dev/vault-secret.yaml
+++ b/apps/clubs/markets/dev/vault-secret.yaml
@@ -17,3 +17,42 @@ spec:
     stringData:
       .dockerconfigjson: '{{ b64dec .docker.config }}'
     type: kubernetes.io/dockerconfigjson
+---
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: VaultSecret
+metadata:
+  name: markets-env-secret
+spec:
+  refreshPeriod: 1h
+  vaultSecretDefinitions:
+    - authentication:
+        path: kubernetes
+        role: secret-reader
+        serviceAccount:
+          name: default
+      name: markets
+      path: kv/data/markets-dev/default/config
+  output:
+    name: markets-env-secret
+    stringData:
+      API_TOKEN_SALT: '{{ .markets.API_TOKEN_SALT }}'
+      API_URL: '{{ .markets.API_URL }}'
+      DJANGO_SUPERUSER_EMAIL: '{{ .markets.DJANGO_SUPERUSER_EMAIL }}'
+      DJANGO_SUPERUSER_PASSWORD: '{{ .markets.DJANGO_SUPERUSER_PASSWORD }}'
+      DJANGO_SUPERUSER_USERNAME: '{{ .markets.DJANGO_SUPERUSER_USERNAME }}'
+      EMAIL_ID: '{{ .markets.EMAIL_ID }}'
+      EMAIL_PW: '{{ .markets.EMAIL_PW }}'
+      FMP_API_KEY: '{{ .markets.FMP_API_KEY }}'
+      FRONTEND_URL: '{{ .markets.FRONTEND_URL }}'
+      GITHUB_BUG_REPORT_TOKEN: '{{ .markets.GITHUB_BUG_REPORT_TOKEN }}'
+      MODERATOR_PASSWORD: '{{ .markets.MODERATOR_PASSWORD }}'
+      PASSWORD_RESET_REDIRECT_URL: '{{ .markets.PASSWORD_RESET_REDIRECT_URL }}'
+      POSTGRES_DB: '{{ .markets.POSTGRES_DB }}'
+      POSTGRES_HOST: '{{ .markets.POSTGRES_HOST }}'
+      POSTGRES_PASSWORD: '{{ .markets.POSTGRES_PASSWORD }}'
+      POSTGRES_PORT: '{{ .markets.POSTGRES_PORT }}'
+      POSTGRES_USER: '{{ .markets.POSTGRES_USER }}'
+      REGISTRATION_KEY: '{{ .markets.REGISTRATION_KEY }}'
+      SALT_SECRET_KEY: '{{ .markets.SALT_SECRET_KEY }}'
+      VITE_API_URL: '{{ .markets.VITE_API_URL }}'
+    type: opaque


### PR DESCRIPTION
Fixes `CreateContainerConfigError` in `markets-dev` (pods already pull images after #384, but fail on missing `markets-env-secret`).

- New VaultSecret `markets-env-secret` in the dev overlay, sourced from `kv/data/markets-dev/default/config` (20 dev-specific keys copied from the live prodv2 `markets-dev` secret — dev URLs/DB host/credentials).
- Vault entry written from prodv2 authoritative values.
- Applied after #384 (both now in dev/vault-secret.yaml).

Prod untouched: its restored `markets-env-secret` works and is intentionally left as-is.