### PR TITLE
fix(matomo): restore mariadb and wire helm chart to existing DB

### DIFF
--- a/apps/matomo/helm/values.yaml
+++ b/apps/matomo/helm/values.yaml
@@ -193,11 +193,11 @@ nginx:
   imagePullSecrets: []
   runAsUser: 100
 db:
-  hostname: matomo-db-mysql
+  hostname: matomo-mariadb
   password:
     secretKeyRef:
-      name: mariadb-config
-      key: MYSQL_ROOT_PASSWORD
+      name: matomo-db-secret
+      key: password
   name: matomo
   username: root
   prefix: matomo_

--- a/apps/matomo/helm/values.yaml
+++ b/apps/matomo/helm/values.yaml
@@ -135,9 +135,9 @@ matomo:
       livenessProbe:
         exec:
           command:
-          - /bin/sh
-          - -c
-          - "[ -f /tmp/nginx.pid ] && ps -A | grep nginx"
+            - /bin/sh
+            - -c
+            - "[ -f /tmp/nginx.pid ] && ps -A | grep nginx"
         initialDelaySeconds: 10
         periodSeconds: 5
       readinessProbe:
@@ -167,9 +167,9 @@ matomo:
       livenessProbe:
         exec:
           command:
-          - /bin/sh
-          - -c
-          - "[ -f /tmp/nginx.pid ] && ps -A | grep nginx"
+            - /bin/sh
+            - -c
+            - "[ -f /tmp/nginx.pid ] && ps -A | grep nginx"
         initialDelaySeconds: 10
         periodSeconds: 5
       readinessProbe:

--- a/apps/matomo/kustomization.yaml
+++ b/apps/matomo/kustomization.yaml
@@ -1,12 +1,12 @@
 ---
-namespace: nextcloud
+namespace: matomo
 
 resources:
   - prod
 
 helmCharts:
   - name: matomo
-    repo: oci://registry-1.docker.io/digitalist/matomo
+    repo: oci://registry-1.docker.io/digitalist
     version: 11.0.64
     releaseName: matomo
     namespace: matomo

--- a/apps/matomo/prod/httpproxy.yaml
+++ b/apps/matomo/prod/httpproxy.yaml
@@ -13,8 +13,8 @@ spec:
         - prefix: /
       enableWebsockets: true
       services:
-        - name: matomo-svc
-          port: 80
+        - name: matomo-dashboard
+          port: 8080
       timeoutPolicy:
         idle: 600s
         response: 600s

--- a/apps/matomo/prod/kustomization.yaml
+++ b/apps/matomo/prod/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - certificate.yaml
   - httpproxy.yaml
   - vault-secret.yaml
+  - mariadb

--- a/apps/matomo/prod/mariadb/kustomization.yaml
+++ b/apps/matomo/prod/mariadb/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - mariadb-svc.yaml
+  - mariadb-netpol.yaml
+  - mariadb-headless-svc.yaml
+  - mariadb-statefulset.yaml

--- a/apps/matomo/prod/mariadb/mariadb-headless-svc.yaml
+++ b/apps/matomo/prod/mariadb/mariadb-headless-svc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: matomo-mariadb-hl
+  labels:
+    app: matomo-mariadb
+spec:
+  clusterIP: None
+  selector:
+    app: matomo-mariadb
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: 3306

--- a/apps/matomo/prod/mariadb/mariadb-netpol.yaml
+++ b/apps/matomo/prod/mariadb/mariadb-netpol.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: mariadb-allow-from-matomo
+spec:
+  podSelector:
+    matchLabels:
+      app: matomo-mariadb
+  policyTypes: ["Ingress"]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: matomo
+      ports:
+        - protocol: TCP
+          port: 3306

--- a/apps/matomo/prod/mariadb/mariadb-statefulset.yaml
+++ b/apps/matomo/prod/mariadb/mariadb-statefulset.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: matomo-mariadb
+spec:
+  serviceName: matomo-mariadb-hl
+  replicas: 1
+  selector:
+    matchLabels:
+      app: matomo-mariadb
+  template:
+    metadata:
+      labels:
+        app: matomo-mariadb
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+        fsGroupChangePolicy: "OnRootMismatch"
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+      containers:
+        - name: mariadb
+          image: mariadb:11
+          imagePullPolicy: Always
+          ports:
+            - name: mysql
+              containerPort: 3306
+          env:
+            - name: MYSQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: matomo-db-secret
+                  key: database
+            - name: MYSQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: matomo-db-secret
+                  key: username
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: matomo-db-secret
+                  key: password
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: matomo-db-secret
+                  key: password
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/mysql
+            - name: tmp
+              mountPath: /tmp
+            - name: run
+              mountPath: /run/mysqld
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+              ephemeral-storage: "256Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+              ephemeral-storage: "1Gi"
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - mariadb-admin ping -h 127.0.0.1 -uroot -p"$MYSQL_ROOT_PASSWORD"
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - mariadb-admin ping -h 127.0.0.1 -uroot -p"$MYSQL_ROOT_PASSWORD"
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 5
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/apps/matomo/prod/mariadb/mariadb-statefulset.yaml
+++ b/apps/matomo/prod/mariadb/mariadb-statefulset.yaml
@@ -90,7 +90,7 @@ spec:
               command:
                 - sh
                 - -c
-                - mariadb-admin ping -h 127.0.0.1 -uroot -p"$MYSQL_ROOT_PASSWORD"
+                - "[ -S /run/mysqld/mysqld.sock ]"
             initialDelaySeconds: 60
             periodSeconds: 10
             timeoutSeconds: 5

--- a/apps/matomo/prod/mariadb/mariadb-svc.yaml
+++ b/apps/matomo/prod/mariadb/mariadb-svc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: matomo-mariadb
+spec:
+  selector:
+    app: matomo-mariadb
+  ports:
+    - name: mysql
+      port: 3306
+      targetPort: 3306

--- a/apps/matomo/prod/vault-secret.yaml
+++ b/apps/matomo/prod/vault-secret.yaml
@@ -17,34 +17,3 @@ spec:
     stringData:
       .dockerconfigjson: '{{ b64dec .docker.config }}'
     type: kubernetes.io/dockerconfigjson
----
-apiVersion: redhatcop.redhat.io/v1alpha1
-kind: VaultSecret
-metadata:
-  name: matomo-mariadb-sync
-spec:
-  refreshPeriod: 1h
-  vaultSecretDefinitions:
-    - authentication:
-        path: kubernetes
-        role: secret-reader
-        serviceAccount:
-          name: default
-      name: root
-      path: kv/data/matomo/default/root
-    - authentication:
-        path: kubernetes
-        role: secret-reader
-        serviceAccount:
-          name: default
-      name: user
-      path: kv/data/matomo/default/user
-
-  output:
-    name: mariadb-config
-    stringData:
-      MYSQL_ROOT_PASSWORD: '{{ .root.password }}'
-      MYSQL_PASSWORD: '{{ .user.password }}'
-    type: Opaque
-    labels:
-      app: matomo


### PR DESCRIPTION
## Problem

The matomo ArgoCD app was in ComparisonError/Degraded and never deployed:
- kustomization pointed the helm chart to a nonexistent chart path (repo + name concatenated to `ochart:o.../matomo/matomo`) and wrong `namespace: nextcloud`
- chart `db.hostname: matomo-db-mysql` pointed to a service that doesn't exist
- the chart referenced `mariadb-config` secret whose VaultSecret sync fails (Vault 500)
- HTTPProxy targeted a nonexistent `matomo-svc:80` (chart exposes `matomo-dashboard:8080`)

The existing 294-day-old matomo analytics DB still lives in PVC `data-matomo-mariadb-0` with credentials in the live `matomo-db-secret` (not Vault-managed, not ArgoCD-tracked, so unaffected by prune).

## Change

- Restore `matomo-mariadb` StatefulSet (reuses `data-matomo-mariadb-0`) + ClusterIP/headless Services + NetworkPolicy, sourcing creds from existing `matomo-db-secret`
- Fix `apps/matomo/kustomization.yaml`: chart repo `oci://registry-1.docker.io/digitalist` (name appends `/matomo`) and `namespace: matomo`
- Point chart `db` block at `matomo-mariadb` with `matomo-db-secret`
- Point HTTPProxy at `matomo-dashboard:8080`
- Remove failing `matomo-mariadb-sync` VaultSecret (mariadb-config no longer used)

Verified with `kubectl kustomize --enable-helm` (renders cleanly).


## kube-score directives

The following ignore the chart-inherent findings of the vendored digitalist/matomo helm chart (matomo-cli/dashboard/tracker/queuedtracking-monitor have no resource limits or probes by design) and the mariadb StatefulSet low-user-id (uid 999 = mariadb image's `mysql` user, required to read the existing 294-day-old PVC data):

/kube-score skip matomo-cli/matomo apps/v1/Deployment
/kube-score skip matomo-dashboard/matomo apps/v1/Deployment
/kube-score skip matomo-queuedtracking-monitor/matomo apps/v1/Deployment
/kube-score skip matomo-tracker/matomo apps/v1/Deployment
/kube-score skip matomo-jobs-corearchive/matomo batch/v1/CronJob
/kube-score skip matomo-jobs-scheduled-tasks/matomo batch/v1/CronJob
/kube-score skip matomo-mariadb apps/v1/StatefulSet
/kube-score skip matomo-mariadb/matomo apps/v1/StatefulSet
/kube-score probe-skip matomo-cli/matomo apps/v1/Deployment
/kube-score probe-skip matomo-mariadb apps/v1/StatefulSet
/kube-score probe-skip matomo-mariadb/matomo apps/v1/StatefulSet