### PR TITLE
fix(matomo): align matomo-tls certificate issuer with existing secret

### DIFF
--- a/apps/matomo/prod/certificate.yaml
+++ b/apps/matomo/prod/certificate.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   secretName: matomo-tls
   issuerRef:
-    name: letsencrypt-etsmtl
+    name: letsencrypt-http
     kind: ClusterIssuer
   commonName: matomo.etsmtl.club
   dnsNames:


### PR DESCRIPTION
The matomo-tls TLS secret (issued today and valid) was issued by `letsencrypt-http`, but `apps/matomo/prod/certificate.yaml` referenced `letsencrypt-etsmtl`. This drives cert-manager into an IncorrectIssuer -> re-issue loop that trips Let's Encrypt rate limits (too many certificates for the same identifiers).

Align the Certificate issuer to `letsencrypt-http` to match the existing issued secret.