### PR TITLE
feat(terraform): add Authentik OIDC provider for Matomo

### DIFF
--- a/.github/workflows/apply-tf.yml
+++ b/.github/workflows/apply-tf.yml
@@ -13,6 +13,7 @@ on:
           - nodered
           - outline
           - coder
+          - matomo
           - all
   push:
     branches:
@@ -22,6 +23,7 @@ on:
       - 'terraform/outline/authentik-vault/**'
       - 'terraform/nodered/authentik-vault/**'
       - 'terraform/coder/authentik-vault/**'
+      - 'terraform/matomo/authentik-vault/**'
 
 jobs:
   terraform_apply:
@@ -58,26 +60,37 @@ jobs:
                 echo "outline=false" >> "$GITHUB_OUTPUT"
                 echo "nodered=true" >> "$GITHUB_OUTPUT"
                 echo "coder=false" >> "$GITHUB_OUTPUT"
+                echo "matomo=false" >> "$GITHUB_OUTPUT"
                 ;;
               outline)
                 echo "outline=true" >> "$GITHUB_OUTPUT"
                 echo "nodered=false" >> "$GITHUB_OUTPUT"
                 echo "coder=false" >> "$GITHUB_OUTPUT"
+                echo "matomo=false" >> "$GITHUB_OUTPUT"
                 ;;
               coder)
                 echo "outline=false" >> "$GITHUB_OUTPUT"
                 echo "nodered=false" >> "$GITHUB_OUTPUT"
                 echo "coder=true" >> "$GITHUB_OUTPUT"
+                echo "matomo=false" >> "$GITHUB_OUTPUT"
+                ;;
+              matomo)
+                echo "outline=false" >> "$GITHUB_OUTPUT"
+                echo "nodered=false" >> "$GITHUB_OUTPUT"
+                echo "coder=false" >> "$GITHUB_OUTPUT"
+                echo "matomo=true" >> "$GITHUB_OUTPUT"
                 ;;
               all)
                 echo "outline=true" >> "$GITHUB_OUTPUT"
                 echo "nodered=true" >> "$GITHUB_OUTPUT"
                 echo "coder=true" >> "$GITHUB_OUTPUT"
+                echo "matomo=true" >> "$GITHUB_OUTPUT"
                 ;;
               auth-only)
                 echo "outline=false" >> "$GITHUB_OUTPUT"
                 echo "nodered=false" >> "$GITHUB_OUTPUT"
                 echo "coder=false" >> "$GITHUB_OUTPUT"
+                echo "matomo=false" >> "$GITHUB_OUTPUT"
                 ;;
               *)
                 echo "Unsupported module: $REQUESTED_MODULE" >&2
@@ -110,6 +123,12 @@ jobs:
             echo "coder=true" >> "$GITHUB_OUTPUT"
           else
             echo "coder=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if grep -q '^terraform/matomo/authentik-vault/' /tmp/changed-files; then
+            echo "matomo=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "matomo=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Authenticate to Vault with GitHub OIDC
@@ -153,6 +172,17 @@ jobs:
           TF_VAR_AUTHENTIK_API_TOKEN: ${{ secrets.AUTHENTIK_TOKEN }}
         run: |
           cd terraform/coder/authentik-vault
+
+          tofu init
+          tofu apply -auto-approve
+
+      - name: Tofu Init & Apply Matomo
+        if: steps.changes.outputs.matomo == 'true'
+        env:
+          TF_IN_AUTOMATION: true
+          TF_VAR_AUTHENTIK_API_TOKEN: ${{ secrets.AUTHENTIK_TOKEN }}
+        run: |
+          cd terraform/matomo/authentik-vault
 
           tofu init
           tofu apply -auto-approve

--- a/terraform/matomo/authentik-vault/main.tf
+++ b/terraform/matomo/authentik-vault/main.tf
@@ -1,0 +1,104 @@
+terraform {
+  required_version = ">=1.14"
+  backend "kubernetes" {
+    secret_suffix = "state-matomo"
+    namespace     = "terraform"
+    config_path   = "~/.kube/config"
+  }
+
+  required_providers {
+    authentik = {
+      source  = "goauthentik/authentik"
+      version = "2026.5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.8.1"
+    }
+    vault = {
+      source  = "hashicorp/vault"
+      version = "5.9.0"
+    }
+  }
+}
+
+provider "authentik" {
+  url   = "https://auth.etsmtl.club"
+  token = var.AUTHENTIK_API_TOKEN
+}
+
+provider "vault" {
+  address          = "https://vault.etsmtl.club"
+  skip_child_token = true
+}
+
+locals {
+  app_slug     = "matomo"
+  app_name     = "Matomo"
+  namespace    = "matomo"
+  hostname     = "matomo.etsmtl.club"
+  vault_secret = "kv/data/${local.namespace}/default/matomo-oidc-secret"
+}
+
+resource "random_password" "matomo_client_secret" {
+  length           = 48
+  special          = true
+  override_special = "!-_="
+}
+
+resource "vault_kv_secret" "matomo_oidc_secret" {
+  path = local.vault_secret
+
+  data_json = jsonencode({
+    OIDC_CLIENT_ID     = authentik_provider_oauth2.matomo.client_id
+    OIDC_CLIENT_SECRET = authentik_provider_oauth2.matomo.client_secret
+  })
+}
+
+data "authentik_flow" "default_authorization_flow" {
+  slug = "default-provider-authorization-explicit-consent"
+}
+
+data "authentik_flow" "default_invalidation_flow" {
+  slug = "default-provider-invalidation-flow"
+}
+
+data "authentik_property_mapping_provider_scope" "openid" {
+  managed = "goauthentik.io/providers/oauth2/scope-openid"
+}
+
+data "authentik_property_mapping_provider_scope" "email" {
+  managed = "goauthentik.io/providers/oauth2/scope-email"
+}
+
+data "authentik_property_mapping_provider_scope" "profile" {
+  managed = "goauthentik.io/providers/oauth2/scope-profile"
+}
+
+resource "authentik_provider_oauth2" "matomo" {
+  name               = local.app_slug
+  client_id          = local.app_slug
+  client_secret      = random_password.matomo_client_secret.result
+  grant_types        = ["authorization_code"]
+  authorization_flow = data.authentik_flow.default_authorization_flow.id
+  invalidation_flow  = data.authentik_flow.default_invalidation_flow.id
+  property_mappings = [
+    data.authentik_property_mapping_provider_scope.openid.id,
+    data.authentik_property_mapping_provider_scope.email.id,
+    data.authentik_property_mapping_provider_scope.profile.id,
+  ]
+
+  allowed_redirect_uris = [
+    {
+      matching_mode     = "strict"
+      redirect_uri_type = "authorization"
+      url               = "https://${local.hostname}/index.php?module=LoginOIDC&action=callback&provider=oidc"
+    },
+  ]
+}
+
+resource "authentik_application" "matomo" {
+  name              = local.app_name
+  slug              = local.app_slug
+  protocol_provider = authentik_provider_oauth2.matomo.id
+}

--- a/terraform/matomo/authentik-vault/variables.tf
+++ b/terraform/matomo/authentik-vault/variables.tf
@@ -1,0 +1,4 @@
+variable "AUTHENTIK_API_TOKEN" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
## Summary
Adds the Authentik OIDC provider + application for Matomo, following the existing `coder`/`nodered`/`outline` pattern (`terraform/*/authentik-vault`). This creates the SSO side only — plugin installation on the Matomo side is intentionally out of scope for now.

- `terraform/matomo/authentik-vault/main.tf`: `authentik_provider_oauth2` (authorization_code), `authentik_application` "Matomo", `random_password` client secret stored in Vault `kv/data/matomo/default/matomo-oidc-secret` (`OIDC_CLIENT_ID`/`OIDC_CLIENT_SECRET`)
- Redirect URI: `https://matomo.etsmtl.club/index.php?module=LoginOIDC&action=callback&provider=oidc` (LoginOIDC plugin callback)
- `.github/workflows/apply-tf.yml`: dispatch option, change detection, and apply step for `matomo`

Follow-ups (not in this PR):
- Vault policy in `k8s-base` needs a `kv/data/matomo/default/matomo-oidc-secret` entry for the CI token
- Matomo-side: install LoginOIDC plugin (custom image or volume) + set DB `SystemSettings` as code + k8s VaultStaticSecret/env wiring