### PR TITLE
fix(nextcloud-new): raise redis master resource limits

### DIFF
--- a/apps/nextcloud-new/helm/nextcloud-values.yaml
+++ b/apps/nextcloud-new/helm/nextcloud-values.yaml
@@ -232,6 +232,13 @@ redis:
       enabled: true
       runAsUser: 10000
       runAsGroup: 10000
+    resources:
+      requests:
+        cpu: 250m
+        memory: 256Mi
+      limits:
+        cpu: 1000m
+        memory: 512Mi
   replica:
     persistence:
       enabled: false


### PR DESCRIPTION
## Summary
- Redis master for `nextcloud-new` was running on the Bitnami chart default limits (150m CPU / 192Mi memory), which measured ~51% of cgroup CPU periods throttled under load.
- This breaks PHP session storage (session.save_handler=redis), which in turn breaks the OIDC login flow: the `state`/timestamp written during `/apps/user_oidc/login` isn't reliably readable at the `/apps/user_oidc/code` callback, producing "The received state has expired."
- Bumps master requests/limits to 250m/256Mi and 1000m/512Mi.

## Test plan
- [x] `kubectl kustomize --enable-helm --load-restrictor LoadRestrictionsNone .` builds cleanly, new resources block present on the `nextcloud-redis-master` StatefulSet
- [ ] After ArgoCD sync, confirm OIDC login on new-nextcloud.etsmtl.club succeeds
- [ ] Spot check cgroup `cpu.stat` on the new pod to confirm throttling drops under similar load