### PR TITLE
fix(distro-mirror): downloads cut off mid-transfer + sync eviction

### DIFF
--- a/apps/distro-mirror/resources/httpproxy.yaml
+++ b/apps/distro-mirror/resources/httpproxy.yaml
@@ -14,11 +14,11 @@ spec:
       # Envoy's default route timeout is 15s for the whole response, which
       # cuts off large ISO/cloud-image downloads mid-transfer -- confirmed
       # live (curl error 18, cut at exactly 15.09s / ~230MB into a 3.2GB
-      # ISO). Multi-gigabyte files can legitimately take a long time on a
-      # slow client connection, so there's no sane finite bound here.
+      # ISO). 4h comfortably covers even a multi-gigabyte file on a slow
+      # connection without leaving truly-stuck transfers open forever.
       timeoutPolicy:
-        response: infinity
-        idle: infinity
+        response: 4h
+        idle: 4h
       services:
         - name: distro-mirror-frontend
           port: 80

--- a/apps/distro-mirror/resources/httpproxy.yaml
+++ b/apps/distro-mirror/resources/httpproxy.yaml
@@ -11,6 +11,14 @@ spec:
   routes:
     - conditions:
         - prefix: /
+      # Envoy's default route timeout is 15s for the whole response, which
+      # cuts off large ISO/cloud-image downloads mid-transfer -- confirmed
+      # live (curl error 18, cut at exactly 15.09s / ~230MB into a 3.2GB
+      # ISO). Multi-gigabyte files can legitimately take a long time on a
+      # slow client connection, so there's no sane finite bound here.
+      timeoutPolicy:
+        response: infinity
+        idle: infinity
       services:
         - name: distro-mirror-frontend
           port: 80

--- a/apps/distro-mirror/resources/sync-cronjobs/sync-ubuntu.yaml
+++ b/apps/distro-mirror/resources/sync-cronjobs/sync-ubuntu.yaml
@@ -155,7 +155,13 @@ spec:
                 limits:
                   cpu: "1"
                   memory: 1Gi
-                  ephemeral-storage: 1Gi
+                  # Must comfortably exceed the "scratch" emptyDir's own
+                  # sizeLimit below: kubelet counts a mounted emptyDir's
+                  # usage against the container's ephemeral-storage limit
+                  # too, on top of the volume's own limit -- learned the
+                  # hard way via a real "Pod ephemeral local storage usage
+                  # exceeds the total limit of containers" eviction.
+                  ephemeral-storage: 22Gi
           volumes:
             - name: scratch
               emptyDir:


### PR DESCRIPTION
## Summary
Two production bugs found immediately after #397 merged and ArgoCD synced:

1. **Downloads cut off after ~15s / ~200-500MB.** The HTTPProxy had no `timeoutPolicy`, so Envoy's default 15s route response timeout was killing every ISO/cloud-image download mid-transfer. Confirmed via curl (`error 18`, cut at exactly 15.09s), and isolated to the Envoy layer by bypassing it (direct RGW and direct-to-nginx-Service both transferred a full 3.2GB file with no cutoff). Sets `response`/`idle` to `infinity`.

2. **sync-ubuntu's push-to-bucket container gets evicted mid-sync.** Its `ephemeral-storage` limit (1Gi) was smaller than the "scratch" emptyDir it mounts (20Gi) — kubelet counts a mounted emptyDir's usage against the *container's* ephemeral-storage limit too, not just the volume's own `sizeLimit`. Real eviction message: `Pod ephemeral local storage usage exceeds the total limit of containers 1Gi`. Raised to 22Gi.

## Test plan
- [x] Reproduced the 15s cutoff live via curl (`downloaded:232792051 ... time:15.086899`)
- [x] Confirmed direct RGW download of the same file completes fully (3.2GB / 46s, no cutoff)
- [x] Confirmed direct-to-nginx-Service (bypassing Envoy) also completes fully, isolating the bug to Envoy's route timeout
- [x] Reproduced the ephemeral-storage eviction live (`reason: Evicted`, exact message above) on `sync-arch`
- [x] `kubectl kustomize` renders cleanly, yamllint clean