### PR TITLE
feat(distro-mirror): replicate mirror to Debian/Fedora/NixOS/Arch/OPNsense

### DIFF
--- a/apps/distro-mirror/kustomization.yaml
+++ b/apps/distro-mirror/kustomization.yaml
@@ -16,3 +16,8 @@ resources:
   - resources/bucket-setup-network-policy.yaml
   - resources/sync-cronjobs/network-policy.yaml
   - resources/sync-cronjobs/sync-ubuntu.yaml
+  - resources/sync-cronjobs/sync-debian.yaml
+  - resources/sync-cronjobs/sync-fedora.yaml
+  - resources/sync-cronjobs/sync-nixos.yaml
+  - resources/sync-cronjobs/sync-arch.yaml
+  - resources/sync-cronjobs/sync-opnsense.yaml

--- a/apps/distro-mirror/resources/sync-cronjobs/sync-arch.yaml
+++ b/apps/distro-mirror/resources/sync-cronjobs/sync-arch.yaml
@@ -1,0 +1,110 @@
+# Arch ships a single always-current rolling ISO -- no discrete supported
+# versions to enumerate, so it's stored under isos/latest/ rather than a
+# version-numbered folder (each run overwrites the previous ISO in place,
+# matching upstream's own "latest" semantics). No rsync module exists for
+# ISOs (only for the pacman package tree, out of scope) -- HTTPS only. No
+# cloud image: Arch doesn't publish an official one.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-arch
+spec:
+  schedule: "0 5 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: distro-mirror-sync
+            distro: arch
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+            - name: fetch-iso
+              image: alpine:3.20
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache curl
+                  mkdir -p /scratch/arch/amd64/isos/latest
+                  curl -fsSL -o /scratch/arch/amd64/isos/latest/archlinux-x86_64.iso \
+                    "https://geo.mirror.pkgbuild.com/iso/latest/archlinux-x86_64.iso"
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+          containers:
+            - name: push-to-bucket
+              image: rclone/rclone:1.68.2
+              imagePullPolicy: Always
+              # apk add (python3 for checksum/index tooling) needs root.
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  export RCLONE_CONFIG_S3_TYPE=s3
+                  export RCLONE_CONFIG_S3_PROVIDER=Ceph
+                  export RCLONE_CONFIG_S3_ENV_AUTH=false
+                  export RCLONE_CONFIG_S3_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+                  export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+                  export RCLONE_CONFIG_S3_ENDPOINT="http://${BUCKET_HOST}:${BUCKET_PORT}"
+                  apk add --no-cache python3
+                  python3 /opt/tooling/compute_checksums.py /scratch/arch
+                  rclone copy /scratch/arch "s3:${BUCKET_NAME}/arch" --transfers=4 --checkers=8 --s3-no-check-bucket
+                  python3 /opt/tooling/generate_index.py
+                  rclone copy /tmp/rendered-index "s3:${BUCKET_NAME}" --s3-no-check-bucket
+              envFrom:
+                - configMapRef:
+                    name: distro-mirror
+                - secretRef:
+                    name: distro-mirror
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+                - name: tooling
+                  mountPath: /opt/tooling
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+                  # Must comfortably exceed the "scratch" emptyDir's own
+                  # sizeLimit below: kubelet counts a mounted emptyDir's
+                  # usage against the container's ephemeral-storage limit
+                  # too, on top of the volume's own limit.
+                  ephemeral-storage: 3Gi
+          volumes:
+            - name: scratch
+              emptyDir:
+                sizeLimit: 2Gi
+            - name: tooling
+              configMap:
+                name: distro-mirror-tooling

--- a/apps/distro-mirror/resources/sync-cronjobs/sync-debian.yaml
+++ b/apps/distro-mirror/resources/sync-cronjobs/sync-debian.yaml
@@ -1,0 +1,143 @@
+# Currently-supported stable release only (13/trixie). The rsync mirror used
+# here (cdimage.debian.org) only carries the current stable tree, not
+# oldstable/12 -- revisit with a different upstream source if oldstable
+# coverage is wanted later. Debian doesn't split server/desktop ISOs the way
+# Ubuntu does: the single netinst image installs either, so there's no
+# separate "desktop" artifact to fetch (debian-edu/-mac are different spins,
+# explicitly excluded, not a desktop variant).
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-debian
+spec:
+  schedule: "15 4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: distro-mirror-sync
+            distro: debian
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+            - name: fetch-iso
+              image: alpine:3.20
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache rsync
+                  mkdir -p /scratch/debian/amd64/isos/13
+                  rsync -rLt \
+                    --exclude="debian-edu-*" \
+                    --exclude="debian-mac-*" \
+                    --include="debian-*-amd64-netinst.iso" \
+                    --exclude="*" \
+                    "rsync://cdimage.debian.org/debian-cd/current/amd64/iso-cd/" /scratch/debian/amd64/isos/13/
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+            - name: fetch-cloud-image
+              image: alpine:3.20
+              imagePullPolicy: Always
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache curl
+                  mkdir -p /scratch/debian/amd64/cloud-images/13
+                  curl -fsSL -o /scratch/debian/amd64/cloud-images/13/debian-13-generic-amd64.qcow2 \
+                    "https://cloud.debian.org/images/cloud/trixie/latest/debian-13-generic-amd64.qcow2"
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+          containers:
+            - name: push-to-bucket
+              image: rclone/rclone:1.68.2
+              imagePullPolicy: Always
+              # apk add (python3 for checksum/index tooling) needs root.
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  export RCLONE_CONFIG_S3_TYPE=s3
+                  export RCLONE_CONFIG_S3_PROVIDER=Ceph
+                  export RCLONE_CONFIG_S3_ENV_AUTH=false
+                  export RCLONE_CONFIG_S3_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+                  export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+                  export RCLONE_CONFIG_S3_ENDPOINT="http://${BUCKET_HOST}:${BUCKET_PORT}"
+                  apk add --no-cache python3
+                  python3 /opt/tooling/compute_checksums.py /scratch/debian
+                  rclone copy /scratch/debian "s3:${BUCKET_NAME}/debian" --transfers=4 --checkers=8 --s3-no-check-bucket
+                  python3 /opt/tooling/generate_index.py
+                  rclone copy /tmp/rendered-index "s3:${BUCKET_NAME}" --s3-no-check-bucket
+              envFrom:
+                - configMapRef:
+                    name: distro-mirror
+                - secretRef:
+                    name: distro-mirror
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+                - name: tooling
+                  mountPath: /opt/tooling
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+                  # Must comfortably exceed the "scratch" emptyDir's own
+                  # sizeLimit below: kubelet counts a mounted emptyDir's
+                  # usage against the container's ephemeral-storage limit
+                  # too, on top of the volume's own limit.
+                  ephemeral-storage: 6Gi
+          volumes:
+            - name: scratch
+              emptyDir:
+                sizeLimit: 5Gi
+            - name: tooling
+              configMap:
+                name: distro-mirror-tooling

--- a/apps/distro-mirror/resources/sync-cronjobs/sync-fedora.yaml
+++ b/apps/distro-mirror/resources/sync-cronjobs/sync-fedora.yaml
@@ -1,0 +1,150 @@
+# Currently-supported releases only (43/44). dl.fedoraproject.org blocks
+# scripted fetches (bot-check), so this goes through a real public mirror
+# instead (fedora.mirrorservice.org). No rsync module was confirmed for
+# point-fetching individual release ISOs, so this is HTTPS-only. Build
+# numbers in filenames (e.g. -43-1.6.iso) aren't predictable, so each fetch
+# scrapes the directory listing for the exact current filename first.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-fedora
+spec:
+  schedule: "30 4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: distro-mirror-sync
+            distro: fedora
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+            - name: fetch-isos
+              image: alpine:3.20
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache curl grep
+                  base="https://fedora.mirrorservice.org/fedora/linux/releases"
+                  for rel in 43 44; do
+                    dir="${base}/${rel}/Server/x86_64/iso/"
+                    mkdir -p "/scratch/fedora/amd64/isos/${rel}"
+                    listing=$(curl -fsSL "$dir")
+                    fname=$(printf '%s' "$listing" | grep -oE "Fedora-Server-dvd-x86_64-${rel}-[0-9.]+\.iso" | head -1)
+                    curl -fsSL -o "/scratch/fedora/amd64/isos/${rel}/${fname}" "${dir}${fname}"
+                  done
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+            - name: fetch-cloud-images
+              image: alpine:3.20
+              imagePullPolicy: Always
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache curl grep
+                  base="https://fedora.mirrorservice.org/fedora/linux/releases"
+                  for rel in 43 44; do
+                    dir="${base}/${rel}/Cloud/x86_64/images/"
+                    mkdir -p "/scratch/fedora/amd64/cloud-images/${rel}"
+                    listing=$(curl -fsSL "$dir")
+                    fname=$(printf '%s' "$listing" | grep -oE "Fedora-Cloud-Base-Generic-${rel}-[0-9.]+\.x86_64\.qcow2" | head -1)
+                    curl -fsSL -o "/scratch/fedora/amd64/cloud-images/${rel}/${fname}" "${dir}${fname}"
+                  done
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+          containers:
+            - name: push-to-bucket
+              image: rclone/rclone:1.68.2
+              imagePullPolicy: Always
+              # apk add (python3 for checksum/index tooling) needs root.
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  export RCLONE_CONFIG_S3_TYPE=s3
+                  export RCLONE_CONFIG_S3_PROVIDER=Ceph
+                  export RCLONE_CONFIG_S3_ENV_AUTH=false
+                  export RCLONE_CONFIG_S3_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+                  export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+                  export RCLONE_CONFIG_S3_ENDPOINT="http://${BUCKET_HOST}:${BUCKET_PORT}"
+                  apk add --no-cache python3
+                  python3 /opt/tooling/compute_checksums.py /scratch/fedora
+                  rclone copy /scratch/fedora "s3:${BUCKET_NAME}/fedora" --transfers=4 --checkers=8 --s3-no-check-bucket
+                  python3 /opt/tooling/generate_index.py
+                  rclone copy /tmp/rendered-index "s3:${BUCKET_NAME}" --s3-no-check-bucket
+              envFrom:
+                - configMapRef:
+                    name: distro-mirror
+                - secretRef:
+                    name: distro-mirror
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+                - name: tooling
+                  mountPath: /opt/tooling
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+                  # Must comfortably exceed the "scratch" emptyDir's own
+                  # sizeLimit below: kubelet counts a mounted emptyDir's
+                  # usage against the container's ephemeral-storage limit
+                  # too, on top of the volume's own limit.
+                  ephemeral-storage: 9Gi
+          volumes:
+            - name: scratch
+              emptyDir:
+                # 2 Server ISOs (~2.5-2.7GB each) + 2 Cloud images
+                # (~600MB each) is ~6.4GB actual; leave headroom.
+                sizeLimit: 8Gi
+            - name: tooling
+              configMap:
+                name: distro-mirror-tooling

--- a/apps/distro-mirror/resources/sync-cronjobs/sync-nixos.yaml
+++ b/apps/distro-mirror/resources/sync-cronjobs/sync-nixos.yaml
@@ -1,0 +1,116 @@
+# NixOS is rolling on a stable-channel cadence: only the current stable
+# channel (26.05) is mirrored, no historical versions. Both the minimal and
+# graphical (GNOME) ISOs are fetched via channels.nixos.org's "latest-"
+# redirect, which always points at the current point release. No rsync
+# module exists for NixOS -- HTTPS only. No separate cloud image: NixOS
+# cloud images are typically built per-deployment via nixos-generators
+# rather than published as a single canonical artifact, so there's nothing
+# analogous to Ubuntu/Debian/Fedora's cloud-images/ to mirror here.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-nixos
+spec:
+  schedule: "45 4 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: distro-mirror-sync
+            distro: nixos
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+            - name: fetch-isos
+              image: alpine:3.20
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache curl
+                  mkdir -p /scratch/nixos/amd64/isos/26.05
+                  for variant in minimal graphical; do
+                    curl -fsSL -o "/scratch/nixos/amd64/isos/26.05/nixos-${variant}-x86_64-linux.iso" \
+                      "https://channels.nixos.org/nixos-26.05/latest-nixos-${variant}-x86_64-linux.iso"
+                  done
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+          containers:
+            - name: push-to-bucket
+              image: rclone/rclone:1.68.2
+              imagePullPolicy: Always
+              # apk add (python3 for checksum/index tooling) needs root.
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  export RCLONE_CONFIG_S3_TYPE=s3
+                  export RCLONE_CONFIG_S3_PROVIDER=Ceph
+                  export RCLONE_CONFIG_S3_ENV_AUTH=false
+                  export RCLONE_CONFIG_S3_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+                  export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+                  export RCLONE_CONFIG_S3_ENDPOINT="http://${BUCKET_HOST}:${BUCKET_PORT}"
+                  apk add --no-cache python3
+                  python3 /opt/tooling/compute_checksums.py /scratch/nixos
+                  rclone copy /scratch/nixos "s3:${BUCKET_NAME}/nixos" --transfers=4 --checkers=8 --s3-no-check-bucket
+                  python3 /opt/tooling/generate_index.py
+                  rclone copy /tmp/rendered-index "s3:${BUCKET_NAME}" --s3-no-check-bucket
+              envFrom:
+                - configMapRef:
+                    name: distro-mirror
+                - secretRef:
+                    name: distro-mirror
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+                - name: tooling
+                  mountPath: /opt/tooling
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+                  # Must comfortably exceed the "scratch" emptyDir's own
+                  # sizeLimit below: kubelet counts a mounted emptyDir's
+                  # usage against the container's ephemeral-storage limit
+                  # too, on top of the volume's own limit.
+                  ephemeral-storage: 8Gi
+          volumes:
+            - name: scratch
+              emptyDir:
+                # minimal (~1.7GB) + graphical (~3.84GB) is ~5.5GB actual;
+                # leave headroom.
+                sizeLimit: 7Gi
+            - name: tooling
+              configMap:
+                name: distro-mirror-tooling

--- a/apps/distro-mirror/resources/sync-cronjobs/sync-opnsense.yaml
+++ b/apps/distro-mirror/resources/sync-cronjobs/sync-opnsense.yaml
@@ -1,0 +1,127 @@
+# Currently-supported series only (26.7). Mirrors the dvd installer image
+# as-is (bz2-compressed, matching upstream -- not decompressed, to avoid
+# roughly doubling storage for content users already expect compressed).
+#
+# custom-cloud-images/ is a placeholder: the CEDILLE/opnsense-cloudinit
+# project (NoCloud provisioning for Proxmox) doesn't publish a downloadable
+# image artifact yet -- it's IaC/tooling (opnseed + OpenTofu + Packer
+# validation), pinned to this same 26.7 base. This CronJob just writes a
+# README so the path exists and is browsable; swap in a real fetch step
+# once that project publishes release assets.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: sync-opnsense
+spec:
+  schedule: "15 5 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 3600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        metadata:
+          labels:
+            app: distro-mirror-sync
+            distro: opnsense
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+            - name: fetch-iso
+              image: alpine:3.20
+              imagePullPolicy: Always
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  apk add --no-cache rsync
+                  mkdir -p /scratch/opnsense/amd64/isos/26.7
+                  rsync -rLt \
+                    --include="OPNsense-*-dvd-amd64.iso.bz2" \
+                    --exclude="*" \
+                    "rsync://pkg.opnsense.org/opnsense-dist/releases/mirror/" /scratch/opnsense/amd64/isos/26.7/
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 128Mi
+                  ephemeral-storage: 128Mi
+                limits:
+                  cpu: "1"
+                  memory: 512Mi
+                  ephemeral-storage: 512Mi
+          containers:
+            - name: push-to-bucket
+              image: rclone/rclone:1.68.2
+              imagePullPolicy: Always
+              # apk add (python3 for checksum/index tooling) needs root.
+              securityContext:
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  export RCLONE_CONFIG_S3_TYPE=s3
+                  export RCLONE_CONFIG_S3_PROVIDER=Ceph
+                  export RCLONE_CONFIG_S3_ENV_AUTH=false
+                  export RCLONE_CONFIG_S3_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID}"
+                  export RCLONE_CONFIG_S3_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY}"
+                  export RCLONE_CONFIG_S3_ENDPOINT="http://${BUCKET_HOST}:${BUCKET_PORT}"
+
+                  mkdir -p /scratch/opnsense/amd64/custom-cloud-images
+                  cat > /scratch/opnsense/amd64/custom-cloud-images/README.txt <<'EOF'
+                  Placeholder: this path will hold custom OPNsense
+                  cloud-init images once the CEDILLE/opnsense-cloudinit
+                  project publishes downloadable release artifacts.
+                  As of this writing it produces provisioning tooling
+                  (opnseed + OpenTofu + Packer validation), not a
+                  standalone image file.
+                  EOF
+
+                  apk add --no-cache python3
+                  python3 /opt/tooling/compute_checksums.py /scratch/opnsense
+                  rclone copy /scratch/opnsense "s3:${BUCKET_NAME}/opnsense" --transfers=4 --checkers=8 --s3-no-check-bucket
+                  python3 /opt/tooling/generate_index.py
+                  rclone copy /tmp/rendered-index "s3:${BUCKET_NAME}" --s3-no-check-bucket
+              envFrom:
+                - configMapRef:
+                    name: distro-mirror
+                - secretRef:
+                    name: distro-mirror
+              volumeMounts:
+                - name: scratch
+                  mountPath: /scratch
+                - name: tooling
+                  mountPath: /opt/tooling
+              resources:
+                requests:
+                  cpu: 100m
+                  memory: 256Mi
+                  ephemeral-storage: 256Mi
+                limits:
+                  cpu: "1"
+                  memory: 1Gi
+                  # Must comfortably exceed the "scratch" emptyDir's own
+                  # sizeLimit below: kubelet counts a mounted emptyDir's
+                  # usage against the container's ephemeral-storage limit
+                  # too, on top of the volume's own limit.
+                  ephemeral-storage: 3Gi
+          volumes:
+            - name: scratch
+              emptyDir:
+                sizeLimit: 2Gi
+            - name: tooling
+              configMap:
+                name: distro-mirror-tooling


### PR DESCRIPTION
## Summary
Replicates the Ubuntu pilot's mirror pattern to the remaining distros from the original plan, using the same per-version hierarchy (`isos/<ver>/`, `cloud-images/<ver>/`), same hardened container pattern, and the same shared tooling ConfigMap for checksums + index generation.

- **Debian**: stable (13/trixie) only — the rsync mirror used (`cdimage.debian.org`) doesn't carry oldstable. Single netinst ISO (no server/desktop split).
- **Fedora**: 43/44, Server ISO + Cloud image, via `fedora.mirrorservice.org` (`dl.fedoraproject.org` blocks scripted fetches). Build-numbered filenames are scraped from the directory listing.
- **NixOS**: current stable channel (26.05) only, minimal + graphical ISOs. No cloud image (none canonically published).
- **Arch**: single always-current rolling ISO under `isos/latest/`. No cloud image.
- **OPNsense**: current series (26.7) dvd installer, mirrored as `.iso.bz2` (matching upstream, not decompressed). `custom-cloud-images/` is a placeholder — `CEDILLE/opnsense-cloudinit` doesn't publish a downloadable image artifact yet.

Every upstream path/filename pattern was verified live (not guessed) before writing the fetch commands.

## Test plan
- [x] All 5 CronJobs run to completion on `cedille-k8s-shared` (real files, not dry-runs)
- [x] Real files land in the bucket under the expected hierarchy (`rclone lsf` verified)
- [x] Root and per-directory index pages render all 6 distros with working navigation (checked in-browser)
- [x] `kubectl kustomize` renders cleanly, yamllint clean
- [x] Full download of a large file (Ubuntu ISO) completes without cutoff, confirming #399's timeout fix holds under real multi-distro load

## Follow-ups (not in scope here)
- Server+Desktop ISOs deferred to production rollout (see ClubCedille/k8s-shared#392)
- `custom-cloud-images/` needs a real fetch step once opnsense-cloudinit publishes artifacts