### PR TITLE
fix(nextcloud-new): reduce loglevel from debug to warning

### DIFF
--- a/apps/nextcloud-new/helm/nextcloud-values.yaml
+++ b/apps/nextcloud-new/helm/nextcloud-values.yaml
@@ -79,7 +79,12 @@ nextcloud:
       $CONFIG = array (
         'log_type' => 'errorlog',
         'logfile' => '/dev/stdout',
-        'loglevel' => 0,
+        # loglevel 0 (debug) makes every WebDAV request (PROPFIND/PUT/MKCOL) emit
+        # full-stack-trace JSON log entries for internal deprecation warnings
+        # (user_oidc lazy AppConfig, IServerContainer alias) and filecache "dirty
+        # table reads" notices. Observed adding multiple seconds of overhead per
+        # request during the group folder migration sync. 2 = warning.
+        'loglevel' => 2,
         'logdateformat' => 'F d, Y H:i:s'
         );
   ## PHP Configuration files


### PR DESCRIPTION
## Summary
- `nextcloud-new`'s `logging.config.php` sets `loglevel: 0` (debug), causing every WebDAV request to emit multiple full-stack-trace JSON log entries for internal deprecation warnings (`user_oidc` lazy AppConfig, `IServerContainer` alias) and filecache "dirty table reads" notices.
- This is suspected to be a major contributor to the slow WebDAV sync observed during the Group Folders migration (single tiny-file PUTs measured at 4-6s).
- Bumps `loglevel` to `2` (warning), matching normal production verbosity.

## Test plan
- [ ] Confirm ArgoCD sync/rollout completes
- [ ] Re-time a single small WebDAV PUT against `nextcloud-new` after rollout
- [ ] Confirm the ongoing Group Folder migration sync speeds up