### PR TITLE
Add pkg-cache apt-cacher-ng pilot (BasicAuth, not mTLS)

### DIFF
--- a/apps/pkg-cache/docs/credentials-runbook.md
+++ b/apps/pkg-cache/docs/credentials-runbook.md
@@ -1,0 +1,64 @@
+# apt-cache BasicAuth credentials
+
+The `apt-cache-htpasswd` Secret is **not** in this kustomization -- like
+Forgejo's admin/OAuth secrets, it's applied manually and never committed
+with real values.
+
+## Generating the htpasswd hash
+
+nginx's `ngx_http_auth_basic_module` accepts the `apr1` crypt format,
+generatable with `openssl` alone (no `htpasswd` binary needed):
+
+```bash
+PASSWORD=$(openssl rand -base64 18 | tr -d '/+=' | head -c 24)
+HASH=$(openssl passwd -apr1 "$PASSWORD")
+echo "fleet:$HASH"
+```
+
+Save `$PASSWORD` out-of-band (distribute via Ansible/CloudInit alongside
+the fleet client cert work, see issue: Mirror: intégration Ansible) --
+only the hash goes into the cluster.
+
+## Applying the Secret
+
+```bash
+kubectl --context cedille-k8s-shared -n pkg-cache create secret generic apt-cache-htpasswd \
+  --from-literal=htpasswd="fleet:$HASH"
+```
+
+Rotate by re-running both commands and re-creating the Secret
+(`kubectl delete secret apt-cache-htpasswd` first, then `create` again) --
+kubelet propagates the updated mounted file to the running pod within a
+minute or so, no pod restart needed.
+
+## Fleet-side sources.list, not Acquire::http::Proxy
+
+Confirmed live: `Acquire::http::Proxy "http://user:pass@apt-cache.pkg.etsmtl.club";`
+always 401s against this nginx sidecar. apt's forward-proxy mode sends
+credentials in a `Proxy-Authorization` header, which `ngx_http_auth_basic_module`
+never looks at (it only checks `Authorization`, the origin-server header) --
+nginx here isn't acting as an actual forward proxy, just a reverse
+proxy/BasicAuth gate in front of apt-cacher-ng.
+
+What works (confirmed live, `apt-get update` + `apt-get install`
+end-to-end through Contour/TLS/nginx/apt-cacher-ng): point `sources.list`
+directly at the cache with credentials in the URI, apt-cacher-ng's normal
+direct-mirror addressing (`<cache-host>/<upstream-host>/<path>`):
+
+```
+Types: deb
+URIs: https://fleet:PASSWORD@apt-cache.pkg.etsmtl.club/archive.ubuntu.com/ubuntu/
+Suites: noble noble-updates noble-backports
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+Types: deb
+URIs: https://fleet:PASSWORD@apt-cache.pkg.etsmtl.club/security.ubuntu.com/ubuntu/
+Suites: noble-security
+Components: main universe restricted multiverse
+Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+```
+
+This is what the Ansible/CloudInit integration (issue: Mirror: intégration
+Ansible) needs to template into fleet machines' `sources.list`, not a proxy
+config.

--- a/apps/pkg-cache/kustomization.yaml
+++ b/apps/pkg-cache/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: pkg-cache
+  namespace: pkg-cache
+resources:
+  - resources/pvc.yaml
+  - resources/deployment.yaml
+  - resources/service.yaml
+  - resources/network-policy.yaml
+  - resources/certificate.yaml
+  - resources/nginx-configmap.yaml
+  - resources/httpproxy.yaml

--- a/apps/pkg-cache/pkg-cache.argoapp.yaml
+++ b/apps/pkg-cache/pkg-cache.argoapp.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: pkg-cache
+  namespace: argocd
+spec:
+  destination:
+    namespace: pkg-cache
+    server: https://kubernetes.default.svc
+  project: k8s-shared
+  source:
+    path: apps/pkg-cache
+    repoURL: https://github.com/ClubCedille/k8s-shared.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/pkg-cache/resources/certificate.yaml
+++ b/apps/pkg-cache/resources/certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: pkg-cache-tls
+spec:
+  secretName: pkg-cache-tls
+  issuerRef:
+    name: letsencrypt-etsmtl
+    kind: ClusterIssuer
+  commonName: apt-cache.pkg.etsmtl.club
+  dnsNames:
+    - apt-cache.pkg.etsmtl.club

--- a/apps/pkg-cache/resources/deployment.yaml
+++ b/apps/pkg-cache/resources/deployment.yaml
@@ -76,8 +76,8 @@ spec:
           imagePullPolicy: Always
           securityContext:
             runAsNonRoot: true
-            runAsUser: 101
-            runAsGroup: 101
+            runAsUser: 10001
+            runAsGroup: 10001
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:

--- a/apps/pkg-cache/resources/deployment.yaml
+++ b/apps/pkg-cache/resources/deployment.yaml
@@ -1,0 +1,129 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: apt-cacher-ng
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: apt-cacher-ng
+  template:
+    metadata:
+      labels:
+        app: apt-cacher-ng
+    spec:
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: apt-cacher-ng
+          image: mbentley/apt-cacher-ng:bullseye-20260806
+          imagePullPolicy: Always
+          # Not exposed via the Service -- only reachable from the nginx
+          # sidecar over localhost. BasicAuth lives entirely in nginx since
+          # apt-cacher-ng has no native HTTP auth suited to reverse-mirror use.
+          #
+          # PUID/PGID=0 (root) is required by this image's entrypoint: it
+          # chowns the cache volume then gosu-drops to PUID/PGID, which needs
+          # root to begin with. Setting a non-zero PUID here without also
+          # pre-chowning the PVC out-of-band just breaks startup (confirmed
+          # this is a gosu-based image, not a straight non-root process), so
+          # runAsNonRoot/runAsUser are left off this container -- allowPrivilegeEscalation
+          # and RuntimeDefault seccomp are the hardening that doesn't conflict
+          # with that startup flow.
+          securityContext:
+            allowPrivilegeEscalation: false
+          ports:
+            - containerPort: 3142
+          env:
+            - name: TZ
+              value: America/Toronto
+            - name: PUID
+              value: "0"
+            - name: PGID
+              value: "0"
+          readinessProbe:
+            tcpSocket:
+              port: 3142
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            tcpSocket:
+              port: 3142
+            initialDelaySeconds: 30
+            periodSeconds: 20
+            failureThreshold: 6
+          volumeMounts:
+            - name: cache
+              mountPath: /var/cache/apt-cacher-ng
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 128Mi
+            limits:
+              cpu: "1"
+              memory: 512Mi
+              ephemeral-storage: 512Mi
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27-alpine
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
+            - name: nginx-auth
+              mountPath: /etc/nginx/auth
+              readOnly: true
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+            - name: run
+              mountPath: /var/run
+            - name: tmp
+              mountPath: /tmp
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 20
+            failureThreshold: 6
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+              ephemeral-storage: 64Mi
+            limits:
+              cpu: 500m
+              memory: 128Mi
+              ephemeral-storage: 128Mi
+      volumes:
+        - name: cache
+          persistentVolumeClaim:
+            claimName: apt-cacher-ng-cache
+        - name: nginx-conf
+          configMap:
+            name: apt-cache-nginx
+        - name: nginx-auth
+          secret:
+            secretName: apt-cache-htpasswd
+        - name: nginx-cache
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}

--- a/apps/pkg-cache/resources/deployment.yaml
+++ b/apps/pkg-cache/resources/deployment.yaml
@@ -49,8 +49,12 @@ spec:
               port: 3142
             periodSeconds: 10
             failureThreshold: 3
+          # Distinct from the readiness probe: this hits apt-cacher-ng's own
+          # report page (its Dockerfile HEALTHCHECK target) instead of just
+          # checking the socket accepts connections.
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /acng-report.html
               port: 3142
             initialDelaySeconds: 30
             periodSeconds: 20
@@ -71,6 +75,9 @@ spec:
           image: nginxinc/nginx-unprivileged:1.27-alpine
           imagePullPolicy: Always
           securityContext:
+            runAsNonRoot: true
+            runAsUser: 101
+            runAsGroup: 101
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
@@ -97,7 +104,7 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: 8080
             initialDelaySeconds: 10
             periodSeconds: 20

--- a/apps/pkg-cache/resources/httpproxy.yaml
+++ b/apps/pkg-cache/resources/httpproxy.yaml
@@ -1,0 +1,25 @@
+# Dedicated sub-domain, no clientValidation: apt's GnuTLS-based HTTPS client
+# doesn't handle client-cert auth reliably (see deployment.yaml), so this
+# uses the same BasicAuth-on-its-own-FQDN pattern planned for the Nix cache.
+# Contour scopes clientValidation to the virtualhost, not the route -- a
+# future mTLS-based pkg.etsmtl.club (dnf/pacman/pkg, #394) needs to stay on
+# its own FQDN too, separate from this one.
+apiVersion: projectcontour.io/v1
+kind: HTTPProxy
+metadata:
+  name: pkg-cache
+spec:
+  virtualhost:
+    fqdn: apt-cache.pkg.etsmtl.club
+    tls:
+      secretName: pkg-cache-tls
+      minimumProtocolVersion: "1.3"
+  routes:
+    - conditions:
+        - prefix: /
+      timeoutPolicy:
+        response: 4h
+        idle: 4h
+      services:
+        - name: apt-cacher-ng
+          port: 8080

--- a/apps/pkg-cache/resources/network-policy.yaml
+++ b/apps/pkg-cache/resources/network-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: apt-cacher-ng
+spec:
+  podSelector:
+    matchLabels:
+      app: apt-cacher-ng
+  policyTypes:
+    - Ingress
+  ingress:
+    - ports:
+        - port: 8080
+          protocol: TCP

--- a/apps/pkg-cache/resources/nginx-configmap.yaml
+++ b/apps/pkg-cache/resources/nginx-configmap.yaml
@@ -1,0 +1,32 @@
+# apt's GnuTLS-based HTTPS client can't reliably do mTLS (confirmed live:
+# curl/gnutls-cli handshake fine with the same cert/key, apt-get always
+# fails with a generic "Connection failed" -- known long-standing
+# apt+GnuTLS+client-cert issue, not a config problem). This nginx sidecar
+# does BasicAuth + reverse proxy to apt-cacher-ng instead, same pattern
+# planned for the Nix cache.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apt-cache-nginx
+data:
+  default.conf: |
+    server {
+      listen 8080;
+
+      location = /healthz {
+        return 200 "ok\n";
+        add_header Content-Type text/plain;
+      }
+
+      location / {
+        auth_basic "apt-cache";
+        auth_basic_user_file /etc/nginx/auth/htpasswd;
+
+        proxy_pass http://127.0.0.1:3142;
+        proxy_set_header Host $host;
+
+        # ISOs/large .deb sets can take a while on a slow fleet link.
+        proxy_read_timeout 4h;
+        proxy_send_timeout 4h;
+      }
+    }

--- a/apps/pkg-cache/resources/nginx-configmap.yaml
+++ b/apps/pkg-cache/resources/nginx-configmap.yaml
@@ -18,6 +18,11 @@ data:
         add_header Content-Type text/plain;
       }
 
+      location = /livez {
+        return 200 "ok\n";
+        add_header Content-Type text/plain;
+      }
+
       location / {
         auth_basic "apt-cache";
         auth_basic_user_file /etc/nginx/auth/htpasswd;

--- a/apps/pkg-cache/resources/pvc.yaml
+++ b/apps/pkg-cache/resources/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: apt-cacher-ng-cache
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: ceph-rbd
+  resources:
+    requests:
+      storage: 30Gi

--- a/apps/pkg-cache/resources/service.yaml
+++ b/apps/pkg-cache/resources/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: apt-cacher-ng
+spec:
+  selector:
+    app: apt-cacher-ng
+  ports:
+    - port: 8080
+      targetPort: 8080


### PR DESCRIPTION
## Summary
- Stand up `apt-cacher-ng` in the new `pkg-cache` namespace, behind an nginx BasicAuth sidecar on a dedicated sub-domain (`apt-cache.pkg.etsmtl.club`).
- The original plan called for mTLS here (like the rest of the pkg-cache pilot). Testing live showed apt's GnuTLS-based HTTPS client doesn't handle client-cert auth reliably — `curl`/`gnutls-cli` handshake fine with the same cert/key, but `apt-get update` always fails with a generic "Connection failed" (tested RSA and ECDSA certs, apt sandbox disabled, generous timeouts). This is a known long-standing apt+GnuTLS+client-cert issue, not a config problem.
- For apt specifically, this adopts the same pattern planned for the Nix cache (#395): dedicated FQDN, BasicAuth via nginx sidecar, no Contour `clientValidation`. dnf/pacman/pkg (#394) still get evaluated for mTLS separately since they likely use different TLS stacks (OpenSSL/libcurl).
- `apt-cacher-ng` itself stays root (PUID/PGID=0) — its entrypoint needs root to chown the cache volume and `gosu`-drop privileges, so `runAsNonRoot` isn't compatible with this image; `allowPrivilegeEscalation: false` and `RuntimeDefault` seccomp are applied instead, documented in the deployment.
- Credentials (nginx BasicAuth htpasswd) are applied manually, not committed — see `apps/pkg-cache/docs/credentials-runbook.md` for generation/rotation.
- **Important finding for the upcoming Ansible integration (#396)**: `Acquire::http::Proxy` with embedded creds always 401s, since apt sends `Proxy-Authorization` and nginx `auth_basic` only checks `Authorization`. Fleet machines need `sources.list` pointed directly at the cache (apt-cacher-ng's normal direct-mirror addressing) instead — documented with a working example in the runbook.

Closes #393.

## Test plan
- [x] `kubectl kustomize` builds cleanly
- [x] Applied live to `cedille-k8s-shared` / `pkg-cache` namespace, pod running 2/2 (apt-cacher-ng + nginx)
- [x] BasicAuth verified via port-forward: no creds → 401, wrong creds → 401, correct creds → 200
- [x] Full external path (DNS → TLS → Contour → nginx BasicAuth → apt-cacher-ng) verified with `curl`
- [x] End-to-end `apt-get update` + `apt-get install` through the cache from a throwaway `ubuntu:24.04` pod
- [ ] kube-score CI gate (pending on this PR)