### PR TITLE
fix(nextcloud-new): raise PHP default_socket_timeout to fix chunked upload 403s

### DIFF
--- a/apps/nextcloud-new/helm/nextcloud-values.yaml
+++ b/apps/nextcloud-new/helm/nextcloud-values.yaml
@@ -92,6 +92,14 @@ nextcloud:
   phpConfigs:
     zz-memory_limit.ini: |-
       memory_limit=1G
+    # PHP's 60s default was truncating the S3 multipart upload stream while
+    # finalizing large (multi-GB) chunked uploads under load, surfacing as a
+    # misleading Sabre\DAV\Exception\Forbidden 403 on the WebDAV MOVE request
+    # (root cause: RuntimeException "Unable to read from stream" during
+    # Aws\S3\MultipartUploader::createPart) during the group folder migration
+    # sync.
+    zz-socket-timeout.ini: |-
+      default_socket_timeout=300
     apc.ini: |-
       apc.enable_cli=1
       apc.shm_segments=1


### PR DESCRIPTION
## Summary
- During the Group Folders migration sync (rclone → nextcloud-new → Garage/S3), large multi-GB video files intermittently failed to finalize with a `Sabre\DAV\Exception\Forbidden: 403 Forbidden` on the WebDAV `MOVE` request.
- Root cause found in the nextcloud-new pod logs (not a permissions issue): PHP's default `default_socket_timeout` (60s) was cutting the S3 multipart upload stream mid-read while Nextcloud finalizes a chunked upload (`RuntimeException: "Unable to read from stream"` inside `Aws\S3\MultipartUploader::createPart`), which Nextcloud wraps into a `GenericFileException` and surfaces as a 403. Larger files (longer finalize time) and higher concurrent load both increase the odds of hitting the 60s ceiling.
- Fix: raise `default_socket_timeout` to 300s via a new `zz-socket-timeout.ini` in `phpConfigs` (same mechanism already used for `zz-memory_limit.ini`).

## Test plan
- [ ] Deploy to `nextcloud-new`, confirm `php -i | grep default_socket_timeout` reflects 300 on the pods
- [ ] Resume/observe the group-folder migration sync and confirm large-file finalize (`MOVE .../uploads/...`) no longer 403s under load
- [ ] Watch `failed_files.txt` / sync.log in the `rclone-migration-admin` pod for a drop in `finalize chunked upload failed` errors