### PR TITLE
fix(nextcloud): avoid full recursive chown on pod restart

### DIFF
--- a/apps/nextcloud-new/helm/nextcloud-values.yaml
+++ b/apps/nextcloud-new/helm/nextcloud-values.yaml
@@ -48,6 +48,12 @@ nextcloud:
   datadir: /var/www/html/data
   persistence:
     subPath:
+  # Set securityContext parameters for the entire pod.
+  podSecurityContext:
+    fsGroup: 33
+    # Avoid a full recursive chown of the CephFS RWX volume on every pod
+    # (re)start - only fix ownership if the root dir doesn't already match.
+    fsGroupChangePolicy: OnRootMismatch
   # Accept both hostnames during the migration/validation window — remove
   # new-nextcloud.etsmtl.club once the domain swap (see plan) is complete.
   trustedDomains:

--- a/apps/nextcloud/helm/nextcloud-values.yaml
+++ b/apps/nextcloud/helm/nextcloud-values.yaml
@@ -58,12 +58,11 @@ nextcloud:
   #   readOnlyRootFilesystem: false
 
   # Set securityContext parameters for the entire pod. For example, you may need to define runAsNonRoot directive
-  # podSecurityContext:
-  #   runAsUser: 10000
-  #   runAsGroup: 10000
-  #   fsGroup: 10000
-  #   runAsNonRoot: true
-  #   readOnlyRootFilesystem: false
+  podSecurityContext:
+    fsGroup: 33
+    # Avoid a full recursive chown of the CephFS RWX volume on every pod
+    # (re)start - only fix ownership if the root dir doesn't already match.
+    fsGroupChangePolicy: OnRootMismatch
 
   configs:
     db.config.php: |-


### PR DESCRIPTION
## Summary
- Set `nextcloud.podSecurityContext.fsGroupChangePolicy: OnRootMismatch` (with explicit `fsGroup: 33` to match the chart's default) for both `nextcloud` and `nextcloud-new`.
- Without this, kubelet's default `fsGroupChangePolicy: Always` triggers a full recursive `chown` of the RWX CephFS data volume on every pod (re)start. With 1M+ files, this took 60+ minutes during today's CephFS remount incident and kept the site down the whole time.
- `OnRootMismatch` skips the recursive chown once the volume root already has the right ownership, only doing the full walk on a genuinely fresh/mismatched volume.

## Test plan
- [x] Rendered both charts locally (`kubectl kustomize --enable-helm`) and confirmed `fsGroup: 33` + `fsGroupChangePolicy: OnRootMismatch` appear on the nextcloud Deployment's pod securityContext for both apps.
- [ ] After merge/sync, confirm a normal pod restart no longer triggers `VolumePermissionChangeInProgress` events (unless ownership is actually wrong).