### PR TITLE
fix(preci): use HTTP health probes instead of tcpSocket

### DIFF
--- a/apps/clubs/preci/wordpress/base/deployment.yaml
+++ b/apps/clubs/preci/wordpress/base/deployment.yaml
@@ -34,19 +34,22 @@ spec:
             - name: http
               containerPort: 80
           startupProbe:
-            tcpSocket:
+            httpGet:
+              path: /wp-login.php
               port: http
             failureThreshold: 30
             periodSeconds: 10
           readinessProbe:
-            tcpSocket:
+            httpGet:
+              path: /wp-login.php
               port: http
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           livenessProbe:
-            tcpSocket:
+            httpGet:
+              path: /wp-login.php
               port: http
             initialDelaySeconds: 60
             periodSeconds: 30


### PR DESCRIPTION
WordPress was reported Running/Ready while Apache served a broken webroot (stale CSI mount left /var/www/html unusable). tcpSocket probes cannot detect that.

Switch startup/readiness/liveness probes to httpGet /wp-login.php which exercises PHP + DB.